### PR TITLE
Scheda viva: tracker denaro

### DIFF
--- a/lib/factory_pg_base.dart
+++ b/lib/factory_pg_base.dart
@@ -24,6 +24,10 @@ class PGBase {
   final List<String> competenzeStrumenti;
   final List<String> abilitaClasse;
   final List<String> equipaggiamento;
+  final int denaroRame;
+  final int denaroArgento;
+  final int denaroOro;
+  final int denaroPlatino;
 
   PGBase({
     String? id,
@@ -49,8 +53,72 @@ class PGBase {
     required this.competenzeStrumenti,
     required this.abilitaClasse,
     required this.equipaggiamento,
+    this.denaroRame = 0,
+    this.denaroArgento = 0,
+    this.denaroOro = 0,
+    this.denaroPlatino = 0,
   }) : id = id ?? const Uuid().v4(),
        dataSalvataggio = dataSalvataggio ?? DateTime.now();
+
+  /// Ritorna una copia del personaggio con i campi indicati sostituiti.
+  PGBase copyWith({
+    String? nome,
+    String? specie,
+    String? classe,
+    int? livello,
+    String? background,
+    String? allineamento,
+    List<String>? competenze,
+    Map<String, int>? caratteristiche,
+    Map<String, int>? modificatori,
+    bool? caratteristicheImpostate,
+    int? velocita,
+    List<String>? linguaggi,
+    List<String>? capacitaSpeciali,
+    int? dadoVita,
+    int? puntiVita,
+    List<String>? tiriSalvezza,
+    List<String>? competenzeArmi,
+    List<String>? competenzeArmature,
+    List<String>? competenzeStrumenti,
+    List<String>? abilitaClasse,
+    List<String>? equipaggiamento,
+    int? denaroRame,
+    int? denaroArgento,
+    int? denaroOro,
+    int? denaroPlatino,
+  }) {
+    return PGBase(
+      id: id,
+      dataSalvataggio: dataSalvataggio,
+      nome: nome ?? this.nome,
+      specie: specie ?? this.specie,
+      classe: classe ?? this.classe,
+      livello: livello ?? this.livello,
+      background: background ?? this.background,
+      allineamento: allineamento ?? this.allineamento,
+      competenze: competenze ?? this.competenze,
+      caratteristiche: caratteristiche ?? this.caratteristiche,
+      modificatori: modificatori ?? this.modificatori,
+      caratteristicheImpostate:
+          caratteristicheImpostate ?? this.caratteristicheImpostate,
+      velocita: velocita ?? this.velocita,
+      linguaggi: linguaggi ?? this.linguaggi,
+      capacitaSpeciali: capacitaSpeciali ?? this.capacitaSpeciali,
+      dadoVita: dadoVita ?? this.dadoVita,
+      puntiVita: puntiVita ?? this.puntiVita,
+      tiriSalvezza: tiriSalvezza ?? this.tiriSalvezza,
+      competenzeArmi: competenzeArmi ?? this.competenzeArmi,
+      competenzeArmature: competenzeArmature ?? this.competenzeArmature,
+      competenzeStrumenti: competenzeStrumenti ?? this.competenzeStrumenti,
+      abilitaClasse: abilitaClasse ?? this.abilitaClasse,
+      equipaggiamento: equipaggiamento ?? this.equipaggiamento,
+      denaroRame: denaroRame ?? this.denaroRame,
+      denaroArgento: denaroArgento ?? this.denaroArgento,
+      denaroOro: denaroOro ?? this.denaroOro,
+      denaroPlatino: denaroPlatino ?? this.denaroPlatino,
+    );
+  }
 
   Map<String, dynamic> toJson() => {
     'id': id,
@@ -76,6 +144,10 @@ class PGBase {
     'competenzeStrumenti': competenzeStrumenti,
     'abilitaClasse': abilitaClasse,
     'equipaggiamento': equipaggiamento,
+    'denaroRame': denaroRame,
+    'denaroArgento': denaroArgento,
+    'denaroOro': denaroOro,
+    'denaroPlatino': denaroPlatino,
   };
 
   factory PGBase.fromJson(Map<String, dynamic> json) => PGBase(
@@ -116,6 +188,10 @@ class PGBase {
     competenzeStrumenti: List<String>.from(json['competenzeStrumenti'] ?? []),
     abilitaClasse: List<String>.from(json['abilitaClasse'] ?? []),
     equipaggiamento: List<String>.from(json['equipaggiamento'] ?? []),
+    denaroRame: json['denaroRame'] as int? ?? 0,
+    denaroArgento: json['denaroArgento'] as int? ?? 0,
+    denaroOro: json['denaroOro'] as int? ?? 0,
+    denaroPlatino: json['denaroPlatino'] as int? ?? 0,
   );
 
   @override

--- a/lib/screens/saved_characters_screen.dart
+++ b/lib/screens/saved_characters_screen.dart
@@ -301,6 +301,13 @@ class _SchedaBottomSheet extends StatelessWidget {
                   _riga('Linguaggi', pg.linguaggi.join(', ')),
                 const Divider(height: 24),
                 const Text(
+                  'Denaro',
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                ),
+                const SizedBox(height: 8),
+                _DenaroSection(pg: pg),
+                const Divider(height: 24),
+                const Text(
                   'Caratteristiche',
                   style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
                 ),
@@ -396,6 +403,96 @@ class _SchedaBottomSheet extends StatelessWidget {
               ),
             );
           }).toList(),
+    );
+  }
+}
+
+/// Tracker del denaro (rame/argento/oro/platino) di un personaggio salvato.
+/// Ogni modifica viene persistita subito tramite [SavedCharactersProvider].
+class _DenaroSection extends StatefulWidget {
+  final PGBase pg;
+
+  const _DenaroSection({required this.pg});
+
+  @override
+  State<_DenaroSection> createState() => _DenaroSectionState();
+}
+
+class _DenaroSectionState extends State<_DenaroSection> {
+  late PGBase _pg;
+
+  @override
+  void initState() {
+    super.initState();
+    _pg = widget.pg;
+  }
+
+  void _aggiorna(String moneta, int delta) {
+    setState(() {
+      switch (moneta) {
+        case 'rame':
+          _pg = _pg.copyWith(
+            denaroRame: (_pg.denaroRame + delta).clamp(0, 1 << 30),
+          );
+          break;
+        case 'argento':
+          _pg = _pg.copyWith(
+            denaroArgento: (_pg.denaroArgento + delta).clamp(0, 1 << 30),
+          );
+          break;
+        case 'oro':
+          _pg = _pg.copyWith(
+            denaroOro: (_pg.denaroOro + delta).clamp(0, 1 << 30),
+          );
+          break;
+        case 'platino':
+          _pg = _pg.copyWith(
+            denaroPlatino: (_pg.denaroPlatino + delta).clamp(0, 1 << 30),
+          );
+          break;
+      }
+    });
+    context.read<SavedCharactersProvider>().save(_pg);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _contatore('Monete di rame (mr)', _pg.denaroRame, 'rame'),
+        _contatore('Monete di argento (ma)', _pg.denaroArgento, 'argento'),
+        _contatore('Monete d\'oro (mo)', _pg.denaroOro, 'oro'),
+        _contatore('Monete di platino (mp)', _pg.denaroPlatino, 'platino'),
+      ],
+    );
+  }
+
+  Widget _contatore(String label, int valore, String moneta) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        children: [
+          Expanded(child: Text(label)),
+          IconButton(
+            onPressed: valore > 0 ? () => _aggiorna(moneta, -1) : null,
+            icon: const Icon(Icons.remove_circle_outline),
+            color: const Color(0xFF8B4513),
+          ),
+          SizedBox(
+            width: 40,
+            child: Text(
+              '$valore',
+              textAlign: TextAlign.center,
+              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+            ),
+          ),
+          IconButton(
+            onPressed: () => _aggiorna(moneta, 1),
+            icon: const Icon(Icons.add_circle_outline),
+            color: const Color(0xFF8B4513),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Cosa cambia
- Aggiunge 4 campi (rame/argento/oro/platino) a `PGBase` con serializzazione JSON.
- Aggiunge un metodo `copyWith` a `PGBase`, pensato per essere riusato dai prossimi tracker della scheda viva (PF, condizioni, inventario, ecc.).
- La scheda di un personaggio salvato (`lib/screens/saved_characters_screen.dart`) mostra ora una sezione "Denaro" con contatori +/- che persistono subito tramite `SavedCharactersProvider`.

## Test
- `flutter analyze`: nessun problema
- `flutter test`: passa

Chiude #11