### PR TITLE
Scheda viva: inventario e pozioni

### DIFF
--- a/lib/factory_pg_base.dart
+++ b/lib/factory_pg_base.dart
@@ -1,5 +1,26 @@
 import 'package:uuid/uuid.dart';
 
+/// Voce di inventario libera (nome + quantita'), distinta
+/// dall'equipaggiamento scelto in fase di creazione del personaggio.
+class InventoryItem {
+  final String nome;
+  final int quantita;
+
+  const InventoryItem({required this.nome, this.quantita = 1});
+
+  InventoryItem copyWith({String? nome, int? quantita}) => InventoryItem(
+    nome: nome ?? this.nome,
+    quantita: quantita ?? this.quantita,
+  );
+
+  Map<String, dynamic> toJson() => {'nome': nome, 'quantita': quantita};
+
+  factory InventoryItem.fromJson(Map<String, dynamic> json) => InventoryItem(
+    nome: json['nome'] as String? ?? '',
+    quantita: json['quantita'] as int? ?? 1,
+  );
+}
+
 class PGBase {
   final String id;
   final DateTime dataSalvataggio;
@@ -30,6 +51,7 @@ class PGBase {
   final int denaroPlatino;
   final int puntiVitaCorrenti;
   final int puntiVitaTemporanei;
+  final List<InventoryItem> inventario;
 
   PGBase({
     String? id,
@@ -61,6 +83,7 @@ class PGBase {
     this.denaroPlatino = 0,
     int? puntiVitaCorrenti,
     this.puntiVitaTemporanei = 0,
+    this.inventario = const [],
   }) : id = id ?? const Uuid().v4(),
        dataSalvataggio = dataSalvataggio ?? DateTime.now(),
        puntiVitaCorrenti = puntiVitaCorrenti ?? puntiVita;
@@ -94,6 +117,7 @@ class PGBase {
     int? denaroPlatino,
     int? puntiVitaCorrenti,
     int? puntiVitaTemporanei,
+    List<InventoryItem>? inventario,
   }) {
     return PGBase(
       id: id,
@@ -126,6 +150,7 @@ class PGBase {
       denaroPlatino: denaroPlatino ?? this.denaroPlatino,
       puntiVitaCorrenti: puntiVitaCorrenti ?? this.puntiVitaCorrenti,
       puntiVitaTemporanei: puntiVitaTemporanei ?? this.puntiVitaTemporanei,
+      inventario: inventario ?? this.inventario,
     );
   }
 
@@ -159,6 +184,7 @@ class PGBase {
     'denaroPlatino': denaroPlatino,
     'puntiVitaCorrenti': puntiVitaCorrenti,
     'puntiVitaTemporanei': puntiVitaTemporanei,
+    'inventario': inventario.map((i) => i.toJson()).toList(),
   };
 
   factory PGBase.fromJson(Map<String, dynamic> json) => PGBase(
@@ -205,6 +231,11 @@ class PGBase {
     denaroPlatino: json['denaroPlatino'] as int? ?? 0,
     puntiVitaCorrenti: json['puntiVitaCorrenti'] as int?,
     puntiVitaTemporanei: json['puntiVitaTemporanei'] as int? ?? 0,
+    inventario:
+        (json['inventario'] as List?)
+            ?.map((i) => InventoryItem.fromJson(i as Map<String, dynamic>))
+            .toList() ??
+        [],
   );
 
   @override

--- a/lib/screens/saved_characters_screen.dart
+++ b/lib/screens/saved_characters_screen.dart
@@ -312,6 +312,13 @@ class _SchedaBottomSheet extends StatelessWidget {
                 _DenaroSection(pg: pg),
                 const Divider(height: 24),
                 const Text(
+                  'Inventario',
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                ),
+                const SizedBox(height: 8),
+                _InventarioSection(pg: pg),
+                const Divider(height: 24),
+                const Text(
                   'Caratteristiche',
                   style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
                 ),
@@ -663,4 +670,143 @@ class _PfSectionState extends State<_PfSection> {
       ),
     ),
   );
+}
+
+/// Inventario libero (oggetti/pozioni) di un personaggio salvato. "Usa" su
+/// una pozione di cura tira 2d4+2 e applica la cura direttamente ai PF.
+class _InventarioSection extends StatefulWidget {
+  final PGBase pg;
+
+  const _InventarioSection({required this.pg});
+
+  @override
+  State<_InventarioSection> createState() => _InventarioSectionState();
+}
+
+class _InventarioSectionState extends State<_InventarioSection> {
+  late PGBase _pg;
+  final _controller = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _pg = widget.pg;
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _salva() => context.read<SavedCharactersProvider>().save(_pg);
+
+  void _aggiungiOggetto() {
+    final nome = _controller.text.trim();
+    if (nome.isEmpty) return;
+
+    final nuovo = List<InventoryItem>.from(_pg.inventario);
+    final idx = nuovo.indexWhere(
+      (i) => i.nome.toLowerCase() == nome.toLowerCase(),
+    );
+    if (idx >= 0) {
+      nuovo[idx] = nuovo[idx].copyWith(quantita: nuovo[idx].quantita + 1);
+    } else {
+      nuovo.add(InventoryItem(nome: nome));
+    }
+
+    setState(() {
+      _pg = _pg.copyWith(inventario: nuovo);
+      _controller.clear();
+    });
+    _salva();
+  }
+
+  void _rimuoviUno(InventoryItem item) {
+    final nuovo = List<InventoryItem>.from(_pg.inventario);
+    final idx = nuovo.indexOf(item);
+    if (idx < 0) return;
+
+    if (item.quantita > 1) {
+      nuovo[idx] = item.copyWith(quantita: item.quantita - 1);
+    } else {
+      nuovo.removeAt(idx);
+    }
+
+    setState(() => _pg = _pg.copyWith(inventario: nuovo));
+    _salva();
+  }
+
+  bool _ePozioneDiCura(String nome) {
+    final n = nome.toLowerCase();
+    return n.contains('cura') || n.contains('guarigion');
+  }
+
+  void _usa(InventoryItem item) {
+    if (_ePozioneDiCura(item.nome)) {
+      final random = Random();
+      final cura = random.nextInt(4) + 1 + random.nextInt(4) + 1 + 2; // 2d4+2
+      final nuoviPf = (_pg.puntiVitaCorrenti + cura).clamp(0, _pg.puntiVita);
+      setState(() => _pg = _pg.copyWith(puntiVitaCorrenti: nuoviPf));
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('${item.nome}: curati $cura PF')));
+    }
+    _rimuoviUno(item);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (_pg.inventario.isEmpty)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Text(
+              'Nessun oggetto',
+              style: TextStyle(color: Colors.grey[600]),
+            ),
+          ),
+        ..._pg.inventario.map(
+          (item) => Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: Row(
+              children: [
+                Expanded(child: Text('${item.nome} ×${item.quantita}')),
+                TextButton(
+                  onPressed: () => _usa(item),
+                  child: const Text('Usa'),
+                ),
+                IconButton(
+                  onPressed: () => _rimuoviUno(item),
+                  icon: const Icon(Icons.remove_circle_outline),
+                  color: Colors.red,
+                ),
+              ],
+            ),
+          ),
+        ),
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _controller,
+                decoration: const InputDecoration(
+                  hintText: 'Aggiungi oggetto...',
+                  isDense: true,
+                ),
+                onSubmitted: (_) => _aggiungiOggetto(),
+              ),
+            ),
+            IconButton(
+              onPressed: _aggiungiOggetto,
+              icon: const Icon(Icons.add_circle),
+              color: const Color(0xFF8B4513),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
 }


### PR DESCRIPTION
## Cosa cambia
- Aggiunge `InventoryItem` (nome + quantita') e il campo `inventario` a `PGBase`, con serializzazione JSON.
- La scheda del personaggio salvato mostra una sezione "Inventario": aggiungi oggetti a testo libero, rimuovili/consumali uno alla volta.
- "Usa" su un oggetto il cui nome contiene "cura" o "guarigion" tira 2d4+2 e applica la cura direttamente ai PF tramite il tracker gia' esistente (PR #22).

## Test
- `flutter analyze`: nessun problema
- `flutter test`: passa

Chiude #12