### PR TITLE
Scheda viva: bonus/malus temporanei e vantaggio/svantaggio

### DIFF
--- a/lib/factory_pg_base.dart
+++ b/lib/factory_pg_base.dart
@@ -53,6 +53,7 @@ class PGBase {
   final int puntiVitaTemporanei;
   final List<InventoryItem> inventario;
   final List<String> condizioniAttive;
+  final List<String> modificatoriAttivi;
 
   PGBase({
     String? id,
@@ -86,6 +87,7 @@ class PGBase {
     this.puntiVitaTemporanei = 0,
     this.inventario = const [],
     this.condizioniAttive = const [],
+    this.modificatoriAttivi = const [],
   }) : id = id ?? const Uuid().v4(),
        dataSalvataggio = dataSalvataggio ?? DateTime.now(),
        puntiVitaCorrenti = puntiVitaCorrenti ?? puntiVita;
@@ -121,6 +123,7 @@ class PGBase {
     int? puntiVitaTemporanei,
     List<InventoryItem>? inventario,
     List<String>? condizioniAttive,
+    List<String>? modificatoriAttivi,
   }) {
     return PGBase(
       id: id,
@@ -155,6 +158,7 @@ class PGBase {
       puntiVitaTemporanei: puntiVitaTemporanei ?? this.puntiVitaTemporanei,
       inventario: inventario ?? this.inventario,
       condizioniAttive: condizioniAttive ?? this.condizioniAttive,
+      modificatoriAttivi: modificatoriAttivi ?? this.modificatoriAttivi,
     );
   }
 
@@ -190,6 +194,7 @@ class PGBase {
     'puntiVitaTemporanei': puntiVitaTemporanei,
     'inventario': inventario.map((i) => i.toJson()).toList(),
     'condizioniAttive': condizioniAttive,
+    'modificatoriAttivi': modificatoriAttivi,
   };
 
   factory PGBase.fromJson(Map<String, dynamic> json) => PGBase(
@@ -242,6 +247,7 @@ class PGBase {
             .toList() ??
         [],
     condizioniAttive: List<String>.from(json['condizioniAttive'] ?? []),
+    modificatoriAttivi: List<String>.from(json['modificatoriAttivi'] ?? []),
   );
 
   @override

--- a/lib/screens/saved_characters_screen.dart
+++ b/lib/screens/saved_characters_screen.dart
@@ -331,6 +331,13 @@ class _SchedaBottomSheet extends StatelessWidget {
                 _CondizioniSection(pg: pg),
                 const Divider(height: 24),
                 const Text(
+                  'Bonus/Malus temporanei',
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                ),
+                const SizedBox(height: 8),
+                _ModificatoriSection(pg: pg),
+                const Divider(height: 24),
+                const Text(
                   'Caratteristiche',
                   style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
                 ),
@@ -922,6 +929,106 @@ class _CondizioniSectionState extends State<_CondizioniSection> {
               ),
             );
           }).toList(),
+    );
+  }
+}
+
+/// Note libere per bonus/malus temporanei e vantaggio/svantaggio attivi
+/// (es. "+2 attacco fino a fine turno", "svantaggio TS Destrezza 3 round").
+class _ModificatoriSection extends StatefulWidget {
+  final PGBase pg;
+
+  const _ModificatoriSection({required this.pg});
+
+  @override
+  State<_ModificatoriSection> createState() => _ModificatoriSectionState();
+}
+
+class _ModificatoriSectionState extends State<_ModificatoriSection> {
+  late PGBase _pg;
+  final _controller = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _pg = widget.pg;
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _salva() => context.read<SavedCharactersProvider>().save(_pg);
+
+  void _aggiungi() {
+    final testo = _controller.text.trim();
+    if (testo.isEmpty) return;
+
+    setState(() {
+      _pg = _pg.copyWith(
+        modificatoriAttivi: [..._pg.modificatoriAttivi, testo],
+      );
+      _controller.clear();
+    });
+    _salva();
+  }
+
+  void _rimuovi(int index) {
+    final nuovi = List<String>.from(_pg.modificatoriAttivi)..removeAt(index);
+    setState(() => _pg = _pg.copyWith(modificatoriAttivi: nuovi));
+    _salva();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (_pg.modificatoriAttivi.isEmpty)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Text(
+              'Nessun modificatore attivo',
+              style: TextStyle(color: Colors.grey[600]),
+            ),
+          ),
+        ..._pg.modificatoriAttivi.asMap().entries.map(
+          (entry) => Padding(
+            padding: const EdgeInsets.only(bottom: 6),
+            child: Row(
+              children: [
+                Expanded(child: Text(entry.value)),
+                IconButton(
+                  onPressed: () => _rimuovi(entry.key),
+                  icon: const Icon(Icons.close, size: 20),
+                  color: Colors.red,
+                ),
+              ],
+            ),
+          ),
+        ),
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _controller,
+                decoration: const InputDecoration(
+                  hintText: 'Es. +2 attacco fino a fine turno',
+                  isDense: true,
+                ),
+                onSubmitted: (_) => _aggiungi(),
+              ),
+            ),
+            IconButton(
+              onPressed: _aggiungi,
+              icon: const Icon(Icons.add_circle),
+              color: const Color(0xFF8B4513),
+            ),
+          ],
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Cosa cambia
- Aggiunge il campo `modificatoriAttivi` (List<String>) a `PGBase`, con serializzazione JSON.
- La scheda del personaggio salvato mostra una sezione "Bonus/Malus temporanei": note libere aggiungibili e rimovibili singolarmente (es. "+2 attacco fino a fine turno").

Parte volutamente semplice (testo libero, nessun collegamento automatico ai tiri) coerente con la natura poco strutturata di questi effetti, come discusso nella issue.

## Test
- `flutter analyze`: nessun problema
- `flutter test`: passa

Chiude #14