### PR TITLE
Scheda viva: tracker slot incantesimo

### DIFF
--- a/lib/factory_pg_base.dart
+++ b/lib/factory_pg_base.dart
@@ -54,6 +54,7 @@ class PGBase {
   final List<InventoryItem> inventario;
   final List<String> condizioniAttive;
   final List<String> modificatoriAttivi;
+  final Map<String, int> slotIncantesimoUsati;
 
   PGBase({
     String? id,
@@ -88,6 +89,7 @@ class PGBase {
     this.inventario = const [],
     this.condizioniAttive = const [],
     this.modificatoriAttivi = const [],
+    this.slotIncantesimoUsati = const {},
   }) : id = id ?? const Uuid().v4(),
        dataSalvataggio = dataSalvataggio ?? DateTime.now(),
        puntiVitaCorrenti = puntiVitaCorrenti ?? puntiVita;
@@ -124,6 +126,7 @@ class PGBase {
     List<InventoryItem>? inventario,
     List<String>? condizioniAttive,
     List<String>? modificatoriAttivi,
+    Map<String, int>? slotIncantesimoUsati,
   }) {
     return PGBase(
       id: id,
@@ -159,6 +162,7 @@ class PGBase {
       inventario: inventario ?? this.inventario,
       condizioniAttive: condizioniAttive ?? this.condizioniAttive,
       modificatoriAttivi: modificatoriAttivi ?? this.modificatoriAttivi,
+      slotIncantesimoUsati: slotIncantesimoUsati ?? this.slotIncantesimoUsati,
     );
   }
 
@@ -195,6 +199,7 @@ class PGBase {
     'inventario': inventario.map((i) => i.toJson()).toList(),
     'condizioniAttive': condizioniAttive,
     'modificatoriAttivi': modificatoriAttivi,
+    'slotIncantesimoUsati': slotIncantesimoUsati,
   };
 
   factory PGBase.fromJson(Map<String, dynamic> json) => PGBase(
@@ -248,6 +253,12 @@ class PGBase {
         [],
     condizioniAttive: List<String>.from(json['condizioniAttive'] ?? []),
     modificatoriAttivi: List<String>.from(json['modificatoriAttivi'] ?? []),
+    slotIncantesimoUsati: Map<String, int>.from(
+      (json['slotIncantesimoUsati'] as Map?)?.map(
+            (k, v) => MapEntry(k as String, (v as num).toInt()),
+          ) ??
+          {},
+    ),
   );
 
   @override

--- a/lib/screens/saved_characters_screen.dart
+++ b/lib/screens/saved_characters_screen.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../data/db_slot_incantesimi.dart';
 import '../factory_pg_base.dart';
 import '../providers/saved_characters_provider.dart';
 import '../widgets/mobile/mobile_scaffold.dart';
@@ -336,6 +337,15 @@ class _SchedaBottomSheet extends StatelessWidget {
                 ),
                 const SizedBox(height: 8),
                 _ModificatoriSection(pg: pg),
+                if (slotIncantesimiList.any((s) => s.classe == pg.classe)) ...[
+                  const Divider(height: 24),
+                  const Text(
+                    'Slot Incantesimo',
+                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                  ),
+                  const SizedBox(height: 8),
+                  _IncantesimiSection(pg: pg),
+                ],
                 const Divider(height: 24),
                 const Text(
                   'Caratteristiche',
@@ -1027,6 +1037,123 @@ class _ModificatoriSectionState extends State<_ModificatoriSection> {
               color: const Color(0xFF8B4513),
             ),
           ],
+        ),
+      ],
+    );
+  }
+}
+
+/// Tracker degli slot incantesimo disponibili/usati per livello, in base a
+/// classe e livello del personaggio (tabella in db_slot_incantesimi.dart).
+class _IncantesimiSection extends StatefulWidget {
+  final PGBase pg;
+
+  const _IncantesimiSection({required this.pg});
+
+  @override
+  State<_IncantesimiSection> createState() => _IncantesimiSectionState();
+}
+
+class _IncantesimiSectionState extends State<_IncantesimiSection> {
+  late PGBase _pg;
+
+  @override
+  void initState() {
+    super.initState();
+    _pg = widget.pg;
+  }
+
+  void _salva() => context.read<SavedCharactersProvider>().save(_pg);
+
+  List<int> get _slotTotaliPerLivello {
+    SlotIncantesimi? tabella;
+    for (final s in slotIncantesimiList) {
+      if (s.classe == _pg.classe) {
+        tabella = s;
+        break;
+      }
+    }
+    return tabella?.slotPerLivello[_pg.livello] ?? const [];
+  }
+
+  int _usati(int livelloIncantesimo) =>
+      _pg.slotIncantesimoUsati['$livelloIncantesimo'] ?? 0;
+
+  void _aggiorna(int livelloIncantesimo, int nuovoValore) {
+    final nuovaMappa = Map<String, int>.from(_pg.slotIncantesimoUsati);
+    nuovaMappa['$livelloIncantesimo'] = nuovoValore;
+    setState(() => _pg = _pg.copyWith(slotIncantesimoUsati: nuovaMappa));
+    _salva();
+  }
+
+  void _usaSlot(int livelloIncantesimo, int totale) {
+    final usatiCorrenti = _usati(livelloIncantesimo);
+    if (usatiCorrenti >= totale) return;
+    _aggiorna(livelloIncantesimo, usatiCorrenti + 1);
+  }
+
+  void _recuperaSlot(int livelloIncantesimo) {
+    final usatiCorrenti = _usati(livelloIncantesimo);
+    if (usatiCorrenti <= 0) return;
+    _aggiorna(livelloIncantesimo, usatiCorrenti - 1);
+  }
+
+  void _riposoLungo() {
+    setState(() => _pg = _pg.copyWith(slotIncantesimoUsati: {}));
+    _salva();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final slotTotali = _slotTotaliPerLivello;
+    if (slotTotali.isEmpty || slotTotali.every((n) => n == 0)) {
+      return Text(
+        'Nessuno slot incantesimo a questo livello.',
+        style: TextStyle(color: Colors.grey[600], fontSize: 13),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (var i = 0; i < slotTotali.length; i++)
+          if (slotTotali[i] > 0)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: Row(
+                children: [
+                  SizedBox(width: 90, child: Text('Livello ${i + 1}')),
+                  IconButton(
+                    onPressed: () => _recuperaSlot(i + 1),
+                    icon: const Icon(Icons.add_circle_outline),
+                    color: Colors.green.shade700,
+                    tooltip: 'Recupera slot',
+                  ),
+                  SizedBox(
+                    width: 56,
+                    child: Text(
+                      '${slotTotali[i] - _usati(i + 1)} / ${slotTotali[i]}',
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: () => _usaSlot(i + 1, slotTotali[i]),
+                    icon: const Icon(Icons.remove_circle_outline),
+                    color: Colors.red,
+                    tooltip: 'Usa slot',
+                  ),
+                ],
+              ),
+            ),
+        const SizedBox(height: 8),
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton.icon(
+            onPressed: _riposoLungo,
+            icon: const Icon(Icons.bedtime),
+            label: const Text('Riposo Lungo'),
+          ),
         ),
       ],
     );


### PR DESCRIPTION
## Cosa cambia
- Aggiunge il campo `slotIncantesimoUsati` (Map<String,int>, per livello incantesimo) a `PGBase`, con serializzazione JSON.
- La scheda di un personaggio con classe incantatrice (Mago, Warlock, Chierico, Druido, Bardo, Stregone, Paladino, Ranger) mostra gli slot disponibili/usati per livello, con azioni rapide per usarne uno o recuperarlo, e un bottone "Riposo Lungo" che li recupera tutti.
- Sezione non mostrata per le classi non incantatrici.

## Nota sullo scope
Non esiste oggi uno step nel wizard per scegliere gli incantesimi conosciuti/preparati di un personaggio, quindi questa PR copre solo il tracciamento degli slot (come discusso nella issue). La selezione degli incantesimi puo' essere un follow-up separato.

## Test
- `flutter analyze`: nessun problema
- `flutter test`: passa

Chiude #10