### PR TITLE
Generatore di incontri per Grado di Sfida

### DIFF
--- a/lib/screens/combat_tracker_screen.dart
+++ b/lib/screens/combat_tracker_screen.dart
@@ -7,6 +7,7 @@ import '../core/app_theme.dart';
 import '../factory_pg_base.dart';
 import '../providers/saved_characters_provider.dart';
 import '../repositories/json_data_repository.dart';
+import '../utils/encounter_generator.dart';
 import '../widgets/mobile/mobile_scaffold.dart';
 
 /// Combattente in una sessione di combattimento (solo in memoria, non
@@ -98,6 +99,41 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
     );
   }
 
+  Future<void> _mostraGeneraIncontro() async {
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder:
+          (_) => _GeneraIncontroSheet(
+            onGenerato: (incontro) {
+              final random = Random();
+              for (final gruppo in incontro.gruppi) {
+                final mostro = gruppo.mostro;
+                final abilityScores = mostro['ability_scores'] as Map?;
+                final destrezza =
+                    (abilityScores?['dexterity'] as num?)?.toInt() ?? 10;
+                final mod = ((destrezza - 10) / 2).floor();
+                final pf = (mostro['hit_points'] as num?)?.toInt() ?? 10;
+                final nome =
+                    mostro['italian_name'] ?? mostro['name'] ?? 'Mostro';
+                for (var i = 0; i < gruppo.quantita; i++) {
+                  _aggiungiCombattente(
+                    _Combattente(
+                      nome: gruppo.quantita > 1 ? '$nome ${i + 1}' : nome,
+                      iniziativa: random.nextInt(20) + 1 + mod,
+                      pfMax: pf,
+                    ),
+                  );
+                }
+              }
+            },
+          ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final ordinati = _ordinati;
@@ -108,6 +144,11 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
     return MobileScaffold(
       title: 'Tracker Combattimento',
       actions: [
+        IconButton(
+          onPressed: _mostraGeneraIncontro,
+          icon: const Icon(Icons.auto_awesome),
+          tooltip: 'Genera incontro',
+        ),
         IconButton(
           onPressed: _combattenti.isEmpty ? null : _nuovoCombattimento,
           icon: const Icon(Icons.refresh),
@@ -476,6 +517,176 @@ class _AggiungiCombattenteSheetState extends State<_AggiungiCombattenteSheet> {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// Genera un incontro casuale bilanciato per il party indicato e lo
+/// restituisce tramite [onGenerato], da usare per popolare il combattimento.
+class _GeneraIncontroSheet extends StatefulWidget {
+  final void Function(IncontroGenerato) onGenerato;
+
+  const _GeneraIncontroSheet({required this.onGenerato});
+
+  @override
+  State<_GeneraIncontroSheet> createState() => _GeneraIncontroSheetState();
+}
+
+class _GeneraIncontroSheetState extends State<_GeneraIncontroSheet> {
+  int _numeroGiocatori = 4;
+  int _livelloMedio = 1;
+  DifficoltaIncontro _difficolta = DifficoltaIncontro.media;
+  bool _generando = false;
+  IncontroGenerato? _risultato;
+
+  static const _nomiDifficolta = {
+    DifficoltaIncontro.facile: 'Facile',
+    DifficoltaIncontro.media: 'Media',
+    DifficoltaIncontro.difficile: 'Difficile',
+    DifficoltaIncontro.mortale: 'Mortale',
+  };
+
+  Future<void> _genera() async {
+    setState(() => _generando = true);
+    final mostri = await JsonDataRepository.loadMonsters();
+    final incontro = generaIncontro(
+      mostriDisponibili: mostri,
+      numeroGiocatori: _numeroGiocatori,
+      livelloMedio: _livelloMedio,
+      difficolta: _difficolta,
+    );
+    if (!mounted) return;
+    setState(() {
+      _risultato = incontro;
+      _generando = false;
+    });
+  }
+
+  void _conferma() {
+    final risultato = _risultato;
+    if (risultato == null || risultato.vuoto) return;
+    widget.onGenerato(risultato);
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: EdgeInsets.only(
+        left: 20,
+        right: 20,
+        top: 20,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 20,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Genera incontro',
+            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('Giocatori'),
+                    Slider(
+                      value: _numeroGiocatori.toDouble(),
+                      min: 1,
+                      max: 8,
+                      divisions: 7,
+                      label: '$_numeroGiocatori',
+                      onChanged:
+                          (v) => setState(() => _numeroGiocatori = v.round()),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('Livello medio party'),
+                    Slider(
+                      value: _livelloMedio.toDouble(),
+                      min: 1,
+                      max: 20,
+                      divisions: 19,
+                      label: '$_livelloMedio',
+                      onChanged:
+                          (v) => setState(() => _livelloMedio = v.round()),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            children:
+                DifficoltaIncontro.values.map((d) {
+                  return ChoiceChip(
+                    label: Text(_nomiDifficolta[d]!),
+                    selected: _difficolta == d,
+                    onSelected: (_) => setState(() => _difficolta = d),
+                  );
+                }).toList(),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: _generando ? null : _genera,
+              child:
+                  _generando
+                      ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                      : const Text('Genera'),
+            ),
+          ),
+          if (_risultato != null) ...[
+            const SizedBox(height: 16),
+            if (_risultato!.vuoto)
+              const Text('Nessun mostro adatto trovato, riprova.')
+            else ...[
+              for (final gruppo in _risultato!.gruppi)
+                Text(
+                  '${gruppo.quantita}x ${gruppo.mostro['italian_name'] ?? gruppo.mostro['name']} (${gruppo.xpTotale} XP)',
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              const SizedBox(height: 4),
+              Text(
+                'Soglia richiesta: ${_risultato!.sogliaRichiesta} XP adeguato',
+                style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _conferma,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF8B4513),
+                    foregroundColor: Colors.white,
+                  ),
+                  child: const Text('Aggiungi al combattimento'),
+                ),
+              ),
+            ],
+          ],
+        ],
+      ),
     );
   }
 }

--- a/lib/utils/encounter_generator.dart
+++ b/lib/utils/encounter_generator.dart
@@ -1,0 +1,162 @@
+import 'dart:math';
+
+/// Difficolta' standard di un incontro D&D 5e.
+enum DifficoltaIncontro { facile, media, difficile, mortale }
+
+/// Soglie di XP per personaggio, per livello 1-20: [facile, media, difficile, mortale].
+/// Tabella standard del DMG.
+const List<List<int>> _sogliaXpPerLivello = [
+  [25, 50, 75, 100],
+  [50, 100, 150, 200],
+  [75, 150, 225, 400],
+  [125, 250, 375, 500],
+  [250, 500, 750, 1100],
+  [300, 600, 900, 1400],
+  [350, 750, 1100, 1700],
+  [450, 900, 1400, 2100],
+  [550, 1100, 1600, 2400],
+  [600, 1200, 1900, 2800],
+  [800, 1600, 2400, 3600],
+  [1000, 2000, 3000, 4500],
+  [1100, 2200, 3400, 5100],
+  [1250, 2500, 3800, 5700],
+  [1400, 2800, 4300, 6400],
+  [1600, 3200, 4800, 7200],
+  [2000, 3900, 5900, 8800],
+  [2100, 4200, 6300, 9500],
+  [2400, 4900, 7300, 10900],
+  [2800, 5700, 8500, 12700],
+];
+
+/// Moltiplicatore di XP in base al numero di mostri nell'incontro (regola DMG).
+double moltiplicatoreXp(int numeroMostri) {
+  if (numeroMostri <= 1) return 1.0;
+  if (numeroMostri == 2) return 1.5;
+  if (numeroMostri <= 6) return 2.0;
+  if (numeroMostri <= 10) return 2.5;
+  if (numeroMostri <= 14) return 3.0;
+  return 4.0;
+}
+
+/// Soglia di XP totale del party per una data difficolta'.
+int sogliaXpParty({
+  required int numeroGiocatori,
+  required int livelloMedio,
+  required DifficoltaIncontro difficolta,
+}) {
+  final livello = livelloMedio.clamp(1, 20);
+  final riga = _sogliaXpPerLivello[livello - 1];
+  return riga[difficolta.index] * numeroGiocatori;
+}
+
+/// Converte una challenge_rating come stringa ("1/4", "1/2", "3") in double.
+double parseCr(String? raw) {
+  if (raw == null || raw.isEmpty) return 0;
+  if (raw.contains('/')) {
+    final parti = raw.split('/');
+    final num = double.tryParse(parti[0]) ?? 0;
+    final den = double.tryParse(parti.length > 1 ? parti[1] : '1') ?? 1;
+    return den == 0 ? 0 : num / den;
+  }
+  return double.tryParse(raw) ?? 0;
+}
+
+/// Un gruppo di mostri identici nell'incontro generato.
+class GruppoMostri {
+  final Map<String, dynamic> mostro;
+  final int quantita;
+
+  const GruppoMostri({required this.mostro, required this.quantita});
+
+  int get xpTotale =>
+      ((mostro['experience_points'] as num?)?.toInt() ?? 0) * quantita;
+}
+
+/// Risultato della generazione di un incontro.
+class IncontroGenerato {
+  final List<GruppoMostri> gruppi;
+  final int xpAdeguato;
+  final int sogliaRichiesta;
+
+  const IncontroGenerato({
+    required this.gruppi,
+    required this.xpAdeguato,
+    required this.sogliaRichiesta,
+  });
+
+  bool get vuoto => gruppi.isEmpty;
+}
+
+/// Genera un incontro casuale bilanciato, scegliendo un singolo tipo di
+/// mostro ripetuto N volte tra quelli con GS adeguato al livello del party,
+/// mirando alla soglia di XP della difficolta' scelta.
+IncontroGenerato generaIncontro({
+  required List<Map<String, dynamic>> mostriDisponibili,
+  required int numeroGiocatori,
+  required int livelloMedio,
+  required DifficoltaIncontro difficolta,
+  Random? random,
+}) {
+  final rnd = random ?? Random();
+  final soglia = sogliaXpParty(
+    numeroGiocatori: numeroGiocatori,
+    livelloMedio: livelloMedio,
+    difficolta: difficolta,
+  );
+
+  if (mostriDisponibili.isEmpty || soglia <= 0) {
+    return IncontroGenerato(
+      gruppi: const [],
+      xpAdeguato: 0,
+      sogliaRichiesta: soglia,
+    );
+  }
+
+  // Filtra mostri con GS ragionevole rispetto al livello del party.
+  final crMinima = max(0, (livelloMedio / 2) - 2);
+  final crMassima = livelloMedio + 3;
+  var pool =
+      mostriDisponibili.where((m) {
+        final cr = parseCr(m['challenge_rating'] as String?);
+        return cr >= crMinima && cr <= crMassima && cr > 0;
+      }).toList();
+
+  if (pool.isEmpty) pool = mostriDisponibili;
+
+  final mostro = pool[rnd.nextInt(pool.length)];
+  final xpUnitario = (mostro['experience_points'] as num?)?.toInt() ?? 0;
+  if (xpUnitario <= 0) {
+    return IncontroGenerato(
+      gruppi: const [],
+      xpAdeguato: 0,
+      sogliaRichiesta: soglia,
+    );
+  }
+
+  // Prova quantita' crescenti e tiene quella che si avvicina di piu' alla
+  // soglia senza superarla eccessivamente (max 8 mostri dello stesso tipo).
+  var migliorN = 1;
+  var migliorDistanza = double.infinity;
+  var migliorXp = 0;
+  for (var n = 1; n <= 8; n++) {
+    final xpAdeguato = (xpUnitario * n * moltiplicatoreXp(n)).round();
+    final distanza = (xpAdeguato - soglia).abs().toDouble();
+    final entroSoglia = xpAdeguato <= soglia * 1.15;
+    if (entroSoglia && distanza < migliorDistanza) {
+      migliorDistanza = distanza;
+      migliorN = n;
+      migliorXp = xpAdeguato;
+    }
+  }
+  if (migliorXp == 0) {
+    // Nessuna quantita' rientra nella soglia (mostro troppo forte): usane 1.
+    migliorN = 1;
+    migliorXp = (xpUnitario * moltiplicatoreXp(1)).round();
+  }
+
+  return IncontroGenerato(
+    gruppi: [GruppoMostri(mostro: mostro, quantita: migliorN)],
+    xpAdeguato: migliorXp,
+    sogliaRichiesta: soglia,
+  );
+}


### PR DESCRIPTION
## Cosa cambia
- Nuovo modulo `lib/utils/encounter_generator.dart`: soglie XP ufficiali per livello/difficolta' (facile/media/difficile/mortale) e moltiplicatore XP per numero di mostri (regola DMG), applicati al database mostri (323 creature).
- Dato numero giocatori, livello medio party e difficolta', sceglie un tipo di mostro con GS adeguato e la quantita' che si avvicina di piu' alla soglia di XP richiesta.
- Integrato nel Tracker Combattimento (PR #30): bottone "Genera incontro" in app bar, il risultato viene aggiunto direttamente alla lista dei combattenti con iniziativa gia' tirata.

## Test
- `flutter analyze`: nessun problema
- `flutter test`: passa

Chiude #18