### PR TITLE
Generatore di bottino/tesoro

### DIFF
--- a/lib/screens/combat_tracker_screen.dart
+++ b/lib/screens/combat_tracker_screen.dart
@@ -8,6 +8,7 @@ import '../factory_pg_base.dart';
 import '../providers/saved_characters_provider.dart';
 import '../repositories/json_data_repository.dart';
 import '../utils/encounter_generator.dart';
+import '../utils/loot_generator.dart';
 import '../widgets/mobile/mobile_scaffold.dart';
 
 /// Combattente in una sessione di combattimento (solo in memoria, non
@@ -134,6 +135,17 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
     );
   }
 
+  Future<void> _mostraGeneraBottino() async {
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => const _GeneraBottinoSheet(),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final ordinati = _ordinati;
@@ -148,6 +160,11 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
           onPressed: _mostraGeneraIncontro,
           icon: const Icon(Icons.auto_awesome),
           tooltip: 'Genera incontro',
+        ),
+        IconButton(
+          onPressed: _mostraGeneraBottino,
+          icon: const Icon(Icons.diamond_outlined),
+          tooltip: 'Genera bottino',
         ),
         IconButton(
           onPressed: _combattenti.isEmpty ? null : _nuovoCombattimento,
@@ -683,6 +700,111 @@ class _GeneraIncontroSheetState extends State<_GeneraIncontroSheet> {
                   child: const Text('Aggiungi al combattimento'),
                 ),
               ),
+            ],
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Genera un bottino casuale (monete + oggetti magici) per il tier scelto,
+/// pescando dal catalogo oggetti magici (assets/data/magic_items.json).
+class _GeneraBottinoSheet extends StatefulWidget {
+  const _GeneraBottinoSheet();
+
+  @override
+  State<_GeneraBottinoSheet> createState() => _GeneraBottinoSheetState();
+}
+
+class _GeneraBottinoSheetState extends State<_GeneraBottinoSheet> {
+  TierBottino _tier = TierBottino.basso;
+  bool _generando = false;
+  Bottino? _risultato;
+
+  Future<void> _genera() async {
+    setState(() => _generando = true);
+    final oggetti = await JsonDataRepository.loadMagicItems();
+    final bottino = generaBottino(tier: _tier, oggettiDisponibili: oggetti);
+    if (!mounted) return;
+    setState(() {
+      _risultato = bottino;
+      _generando = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final risultato = _risultato;
+    return SingleChildScrollView(
+      padding: EdgeInsets.only(
+        left: 20,
+        right: 20,
+        top: 20,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 20,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Genera bottino',
+            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children:
+                TierBottino.values.map((t) {
+                  return ChoiceChip(
+                    label: Text(nomeTier(t)),
+                    selected: _tier == t,
+                    onSelected: (_) => setState(() => _tier = t),
+                  );
+                }).toList(),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: _generando ? null : _genera,
+              child:
+                  _generando
+                      ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                      : const Text('Genera'),
+            ),
+          ),
+          if (risultato != null) ...[
+            const SizedBox(height: 16),
+            const Text('Monete', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 4),
+            Text(
+              [
+                if (risultato.platino > 0) '${risultato.platino} mp',
+                if (risultato.oro > 0) '${risultato.oro} mo',
+                if (risultato.argento > 0) '${risultato.argento} ma',
+                if (risultato.rame > 0) '${risultato.rame} mr',
+              ].join(', '),
+            ),
+            if (risultato.oggettiMagici.isNotEmpty) ...[
+              const SizedBox(height: 16),
+              const Text(
+                'Oggetti magici',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 4),
+              for (final oggetto in risultato.oggettiMagici)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 6),
+                  child: Text(
+                    '${oggetto['italian_name'] ?? oggetto['name']} (${oggetto['rarity']})',
+                  ),
+                ),
             ],
           ],
         ],

--- a/lib/utils/loot_generator.dart
+++ b/lib/utils/loot_generator.dart
@@ -1,0 +1,107 @@
+import 'dart:math';
+
+/// Livello di importanza dell'incontro/tesoro, in base al Grado di Sfida.
+enum TierBottino { basso, medio, alto, epico }
+
+const _nomiTier = {
+  TierBottino.basso: 'Basso (GS 0-4)',
+  TierBottino.medio: 'Medio (GS 5-10)',
+  TierBottino.alto: 'Alto (GS 11-16)',
+  TierBottino.epico: 'Epico (GS 17+)',
+};
+
+String nomeTier(TierBottino tier) => _nomiTier[tier]!;
+
+/// Determina il tier di bottino da un Grado di Sfida numerico.
+TierBottino tierDaCr(double cr) {
+  if (cr <= 4) return TierBottino.basso;
+  if (cr <= 10) return TierBottino.medio;
+  if (cr <= 16) return TierBottino.alto;
+  return TierBottino.epico;
+}
+
+/// Bottino generato: monete e oggetti magici.
+class Bottino {
+  final int rame;
+  final int argento;
+  final int oro;
+  final int platino;
+  final List<Map<String, dynamic>> oggettiMagici;
+
+  const Bottino({
+    this.rame = 0,
+    this.argento = 0,
+    this.oro = 0,
+    this.platino = 0,
+    this.oggettiMagici = const [],
+  });
+}
+
+/// Genera un bottino casuale (monete + 0-2 oggetti magici) adeguato al tier.
+Bottino generaBottino({
+  required TierBottino tier,
+  required List<Map<String, dynamic>> oggettiDisponibili,
+  Random? random,
+}) {
+  final rnd = random ?? Random();
+  var rame = 0;
+  var argento = 0;
+  var oro = 0;
+  var platino = 0;
+  late final List<String> raritaAmmesse;
+  late final List<double> sogliaOggetti; // [soglia 0 oggetti, soglia 1 oggetto]
+
+  switch (tier) {
+    case TierBottino.basso:
+      rame = (rnd.nextInt(6) + 1) * 10;
+      argento = (rnd.nextInt(6) + 1) * 10;
+      oro = (rnd.nextInt(6) + 1) * 10;
+      raritaAmmesse = ['common', 'uncommon'];
+      sogliaOggetti = [0.6, 0.9];
+      break;
+    case TierBottino.medio:
+      argento = (rnd.nextInt(6) + 1) * 100;
+      oro = (rnd.nextInt(8) + 1) * 100;
+      raritaAmmesse = ['uncommon', 'rare'];
+      sogliaOggetti = [0.4, 0.8];
+      break;
+    case TierBottino.alto:
+      oro = (rnd.nextInt(10) + 1) * 1000;
+      platino = (rnd.nextInt(6) + 1) * 10;
+      raritaAmmesse = ['rare', 'very rare'];
+      sogliaOggetti = [0.2, 0.6];
+      break;
+    case TierBottino.epico:
+      oro = (rnd.nextInt(10) + 1) * 10000;
+      platino = (rnd.nextInt(8) + 1) * 1000;
+      raritaAmmesse = ['very rare', 'legendary'];
+      sogliaOggetti = [0.1, 0.4];
+      break;
+  }
+
+  final tiro = rnd.nextDouble();
+  final numOggetti =
+      tiro < sogliaOggetti[0] ? 0 : (tiro < sogliaOggetti[1] ? 1 : 2);
+
+  var pool =
+      oggettiDisponibili.where((o) {
+        final r = (o['rarity'] as String? ?? '').toLowerCase();
+        return raritaAmmesse.any((target) => r.contains(target));
+      }).toList();
+  if (pool.isEmpty) pool = oggettiDisponibili;
+
+  final oggettiScelti = <Map<String, dynamic>>[];
+  final disponibili = List<Map<String, dynamic>>.from(pool);
+  for (var i = 0; i < numOggetti && disponibili.isNotEmpty; i++) {
+    final idx = rnd.nextInt(disponibili.length);
+    oggettiScelti.add(disponibili.removeAt(idx));
+  }
+
+  return Bottino(
+    rame: rame,
+    argento: argento,
+    oro: oro,
+    platino: platino,
+    oggettiMagici: oggettiScelti,
+  );
+}


### PR DESCRIPTION
## Cosa cambia
- Nuovo modulo `lib/utils/loot_generator.dart`: dato un tier (basso GS 0-4, medio 5-10, alto 11-16, epico 17+), genera monete (scala rame/argento/oro/platino gia' usata nel tracker denaro, PR #21) e 0-2 oggetti magici pescati da `assets/data/magic_items.json` filtrando per rarita' adeguata al tier.
- Integrato nel Tracker Combattimento (bottone "Genera bottino" in app bar, a fianco del generatore di incontri di PR #31).

## Test
- `flutter analyze`: nessun problema
- `flutter test`: passa

Chiude #17