### PR TITLE
Scaffold pubblicitario (AdMob) con ID di test

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -56,6 +56,11 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <!-- AdMob App ID di TEST (Google). Sostituire con l'App ID reale
+             del proprio account AdMob prima della pubblicazione. -->
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:provider/provider.dart';
 
 // === IMPORTAZIONI ===
@@ -12,11 +13,16 @@ import 'screens/combat_tracker_screen.dart'; // Tracker iniziativa/combattimento
 import 'package:dnd_master_aid/factory_pg_base.dart';
 import 'providers/character_provider.dart';
 import 'providers/saved_characters_provider.dart';
+import 'widgets/banner_ad_widget.dart';
 import 'widgets/mobile/mobile_scaffold.dart';
 import 'widgets/mobile/mobile_card.dart';
 import 'pages/database_browser_page.dart';
 
 void main() {
+  if (adsSupportedPlatform) {
+    WidgetsFlutterBinding.ensureInitialized();
+    MobileAds.instance.initialize();
+  }
   runApp(const DnDMasterAidApp());
 }
 
@@ -122,12 +128,19 @@ class HomePage extends StatelessWidget {
           child: Image.asset('assets/icon/icon.png'),
         ),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(AppSpacing.lg),
-        child:
-            isMobile
-                ? _buildMobileLayout(context, attive, inArrivo)
-                : _buildTabletLayout(context, attive, inArrivo),
+      body: Column(
+        children: [
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(AppSpacing.lg),
+              child:
+                  isMobile
+                      ? _buildMobileLayout(context, attive, inArrivo)
+                      : _buildTabletLayout(context, attive, inArrivo),
+            ),
+          ),
+          const Center(child: BannerAdWidget()),
+        ],
       ),
     );
   }

--- a/lib/widgets/banner_ad_widget.dart
+++ b/lib/widgets/banner_ad_widget.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+
+/// Ad unit ID di TEST forniti da Google (mostrano annunci finti, nessun
+/// rischio di violare le policy usando per errore ID reali in sviluppo).
+/// Sostituire con gli ad unit ID reali del proprio account AdMob prima
+/// della pubblicazione.
+const String _androidBannerTestId = 'ca-app-pub-3940256099942544/6300978111';
+
+/// True solo sulle piattaforme dove google_mobile_ads e' supportato
+/// (Android/iOS). L'SDK non esiste per web/desktop.
+bool get adsSupportedPlatform =>
+    !kIsWeb &&
+    (defaultTargetPlatform == TargetPlatform.android ||
+        defaultTargetPlatform == TargetPlatform.iOS);
+
+/// Banner pubblicitario da mostrare in punti non invasivi dell'app (mai
+/// durante il combattimento o la scheda live di un personaggio). Non
+/// disegna nulla se la piattaforma non e' supportata o l'annuncio non
+/// carica.
+class BannerAdWidget extends StatefulWidget {
+  const BannerAdWidget({super.key});
+
+  @override
+  State<BannerAdWidget> createState() => _BannerAdWidgetState();
+}
+
+class _BannerAdWidgetState extends State<BannerAdWidget> {
+  BannerAd? _bannerAd;
+  bool _caricato = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (adsSupportedPlatform) _caricaBanner();
+  }
+
+  void _caricaBanner() {
+    final banner = BannerAd(
+      adUnitId: _androidBannerTestId,
+      size: AdSize.banner,
+      request: const AdRequest(),
+      listener: BannerAdListener(
+        onAdLoaded: (_) {
+          if (mounted) setState(() => _caricato = true);
+        },
+        onAdFailedToLoad: (ad, error) => ad.dispose(),
+      ),
+    );
+    banner.load();
+    _bannerAd = banner;
+  }
+
+  @override
+  void dispose() {
+    _bannerAd?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final banner = _bannerAd;
+    if (!adsSupportedPlatform || !_caricato || banner == null) {
+      return const SizedBox.shrink();
+    }
+    return SizedBox(
+      width: banner.size.width.toDouble(),
+      height: banner.size.height.toDouble(),
+      child: AdWidget(ad: banner),
+    );
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,9 +8,11 @@ import Foundation
 import open_file_mac
 import path_provider_foundation
 import shared_preferences_foundation
+import webview_flutter_wkwebview
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   OpenFilePlugin.register(with: registry.registrar(forPlugin: "OpenFilePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -200,6 +200,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  google_mobile_ads:
+    dependency: "direct main"
+    description:
+      name: google_mobile_ads
+      sha256: "6029f6c48bc9b6b47767ddbb4847683048a2f006d418c871bd93c5eb6a8e5c3c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
   html:
     dependency: transitive
     description:
@@ -645,6 +653,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  webview_flutter:
+    dependency: transitive
+    description:
+      name: webview_flutter
+      sha256: d53e1ccf5516f25017e3c9d44c39034db352d20fa34fe200674270242c2c5111
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.14.1"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: a97db7a44f8e71af2f3971c45550a08cce1fb60059c1b8e534251e6cfb753490
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.0"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "1221c1b12f5278791042f2ec2841743784cf25c5a644e23d6680e5d718824f04"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.15.1"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: c879dd64b87c452aa84381b244d5469da57ba7e8cca6884c7b1e0d406372c12d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.26.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -670,5 +710,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.29.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  google_mobile_ads: ^9.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Cosa cambia
- Aggiunge `google_mobile_ads`, inizializzato solo su Android/iOS (l'SDK non supporta web/desktop). Verificato che `flutter build web` continua a funzionare correttamente.
- Nuovo `BannerAdWidget` riusabile con l'**ad unit ID di TEST ufficiale di Google** (mai reale), mostrato in un punto non invasivo della Home (in fondo, sotto le funzioni) — mai nella scheda viva o nel tracker di combattimento.
- Aggiunge il meta-data `APPLICATION_ID` di test nel manifest Android.

## Prima di pubblicare (da fare manualmente, non incluso qui)
- Sostituire gli ID di test con quelli reali del tuo account AdMob.
- Aggiornare privacy policy e gestire il consenso GDPR (l'app dichiara oggi "nessun dato raccolto" - con le ads questo cambia).
- Dichiarare la presenza di pubblicita' nella Data Safety di Google Play Console.

## Test
- `flutter analyze`: nessun problema
- `flutter test`: passa
- `flutter build web`: verificato, nessuna regressione

Chiude #19