### PR TITLE
Aggiunge generatore di card incantesimi per il Master

### DIFF
--- a/lib/screens/combat_tracker_screen.dart
+++ b/lib/screens/combat_tracker_screen.dart
@@ -12,6 +12,7 @@ import '../repositories/json_data_repository.dart';
 import '../utils/encounter_generator.dart';
 import '../utils/loot_generator.dart';
 import '../widgets/mobile/mobile_scaffold.dart';
+import 'spell_cards_screen.dart';
 
 /// Combattente in una sessione di combattimento (solo in memoria, non
 /// persistito: la scheda viva del PG resta la fonte di verita' per PF e
@@ -596,6 +597,16 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
     return MobileScaffold(
       title: 'Tracker Combattimento',
       actions: [
+        IconButton(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const SpellCardsScreen()),
+            );
+          },
+          icon: const Icon(Icons.auto_stories),
+          tooltip: 'Card incantesimi',
+        ),
         IconButton(
           onPressed: _mostraGeneraIncontro,
           icon: const Icon(Icons.auto_awesome),

--- a/lib/screens/saved_characters_screen.dart
+++ b/lib/screens/saved_characters_screen.dart
@@ -7,6 +7,7 @@ import '../data/db_slot_incantesimi.dart';
 import '../factory_pg_base.dart';
 import '../providers/saved_characters_provider.dart';
 import '../widgets/mobile/mobile_scaffold.dart';
+import 'spell_cards_screen.dart';
 
 class SavedCharactersScreen extends StatefulWidget {
   const SavedCharactersScreen({super.key});
@@ -1105,6 +1106,20 @@ class _IncantesimiSectionState extends State<_IncantesimiSection> {
             onPressed: _riposoLungo,
             icon: const Icon(Icons.bedtime),
             label: const Text('Riposo Lungo'),
+          ),
+        ),
+        const SizedBox(height: 8),
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton.icon(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const SpellCardsScreen()),
+              );
+            },
+            icon: const Icon(Icons.auto_stories),
+            label: const Text('Card incantesimi'),
           ),
         ),
       ],

--- a/lib/screens/spell_cards_screen.dart
+++ b/lib/screens/spell_cards_screen.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+
+import '../core/app_theme.dart';
+import '../data/db_incantesimi.dart';
+import '../repositories/json_data_repository.dart';
+import '../widgets/mobile/mobile_scaffold.dart';
+import '../widgets/spell_card.dart';
+
+/// Genera card riassuntive per gli incantesimi rilevanti di un PG o di un
+/// mostro/PNG: si cerca l'incantesimo per nome e lo si aggiunge al mazzo di
+/// card da consultare rapidamente durante la sessione.
+class SpellCardsScreen extends StatefulWidget {
+  final List<String> nomiIniziali;
+
+  const SpellCardsScreen({super.key, this.nomiIniziali = const []});
+
+  @override
+  State<SpellCardsScreen> createState() => _SpellCardsScreenState();
+}
+
+class _SpellCardsScreenState extends State<SpellCardsScreen> {
+  final _searchController = TextEditingController();
+  List<Incantesimo> _risultati = [];
+  final List<Incantesimo> _selezionati = [];
+  bool _caricamentoIniziale = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.nomiIniziali.isNotEmpty) _caricaIniziali();
+  }
+
+  Future<void> _caricaIniziali() async {
+    setState(() => _caricamentoIniziale = true);
+    final tutti = await JsonDataRepository.loadSpells();
+    if (!mounted) return;
+    setState(() {
+      for (final nome in widget.nomiIniziali) {
+        final trovato = tutti.firstWhere(
+          (s) => s.nome.toLowerCase() == nome.toLowerCase(),
+          orElse:
+              () => Incantesimo(
+                nome: '',
+                livello: 0,
+                scuola: '',
+                classi: const [],
+                descrizione: '',
+                raggio: '',
+                durata: '',
+                tempoLancio: '',
+                componenti: const [],
+              ),
+        );
+        if (trovato.nome.isNotEmpty) _selezionati.add(trovato);
+      }
+      _caricamentoIniziale = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _cerca(String query) async {
+    if (query.trim().isEmpty) {
+      setState(() => _risultati = []);
+      return;
+    }
+    final risultati = await JsonDataRepository.searchSpells(query: query);
+    if (!mounted) return;
+    setState(() => _risultati = risultati.take(20).toList());
+  }
+
+  void _aggiungi(Incantesimo incantesimo) {
+    setState(() {
+      if (!_selezionati.any((s) => s.nome == incantesimo.nome)) {
+        _selezionati.add(incantesimo);
+      }
+      _risultati = [];
+      _searchController.clear();
+    });
+  }
+
+  void _rimuovi(Incantesimo incantesimo) {
+    setState(() => _selezionati.removeWhere((s) => s.nome == incantesimo.nome));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MobileScaffold(
+      title: 'Card Incantesimi',
+      body: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _searchController,
+              decoration: const InputDecoration(
+                hintText: 'Cerca incantesimo per nome...',
+                prefixIcon: Icon(Icons.search),
+              ),
+              onChanged: _cerca,
+            ),
+            if (_risultati.isNotEmpty)
+              Container(
+                constraints: const BoxConstraints(maxHeight: 220),
+                margin: const EdgeInsets.only(top: AppSpacing.sm),
+                decoration: BoxDecoration(
+                  border: Border.all(color: Colors.grey.shade300),
+                  borderRadius: BorderRadius.circular(AppRadius.sm),
+                ),
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  itemCount: _risultati.length,
+                  itemBuilder: (context, index) {
+                    final s = _risultati[index];
+                    return ListTile(
+                      dense: true,
+                      title: Text(s.nome),
+                      subtitle: Text(
+                        s.eTrucchetto
+                            ? 'Trucchetto · ${s.scuola}'
+                            : 'Livello ${s.livello} · ${s.scuola}',
+                      ),
+                      onTap: () => _aggiungi(s),
+                    );
+                  },
+                ),
+              ),
+            const SizedBox(height: AppSpacing.md),
+            Expanded(
+              child:
+                  _caricamentoIniziale
+                      ? const Center(child: CircularProgressIndicator())
+                      : _selezionati.isEmpty
+                      ? Center(
+                        child: Text(
+                          'Nessuna card. Cerca un incantesimo per aggiungerlo\nal mazzo da consultare durante la sessione.',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(color: Colors.grey[600]),
+                        ),
+                      )
+                      : ListView.builder(
+                        itemCount: _selezionati.length,
+                        itemBuilder: (context, index) {
+                          final s = _selezionati[index];
+                          return SpellCard(
+                            incantesimo: s,
+                            onRemove: () => _rimuovi(s),
+                          );
+                        },
+                      ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/spell_card.dart
+++ b/lib/widgets/spell_card.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import '../core/app_theme.dart';
+import '../data/db_incantesimi.dart';
+
+/// Card riassuntiva di un incantesimo, pensata per essere consultata
+/// rapidamente dal Master durante la sessione di gioco.
+class SpellCard extends StatelessWidget {
+  final Incantesimo incantesimo;
+  final VoidCallback? onRemove;
+
+  const SpellCard({super.key, required this.incantesimo, this.onRemove});
+
+  @override
+  Widget build(BuildContext context) {
+    final i = incantesimo;
+    return Card(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.md),
+      ),
+      margin: const EdgeInsets.only(bottom: AppSpacing.sm),
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    i.nome,
+                    style: const TextStyle(
+                      fontSize: 17,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                if (onRemove != null)
+                  IconButton(
+                    onPressed: onRemove,
+                    icon: const Icon(Icons.close),
+                    color: Colors.grey,
+                    visualDensity: VisualDensity.compact,
+                  ),
+              ],
+            ),
+            Text(
+              i.eTrucchetto
+                  ? 'Trucchetto · ${i.scuola}'
+                  : 'Livello ${i.livello} · ${i.scuola}',
+              style: TextStyle(color: Colors.grey[600], fontSize: 13),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Wrap(
+              spacing: AppSpacing.md,
+              runSpacing: 4,
+              children: [
+                _Dettaglio('Tempo di lancio', i.tempoLancio),
+                _Dettaglio('Raggio', i.raggio),
+                _Dettaglio('Componenti', i.componenti.join(', ')),
+                _Dettaglio('Durata', i.durata),
+              ],
+            ),
+            if (i.classi.isNotEmpty) ...[
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                'Classi: ${i.classi.join(', ')}',
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+            ],
+            const SizedBox(height: AppSpacing.sm),
+            Text(i.descrizione),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Dettaglio extends StatelessWidget {
+  final String label;
+  final String valore;
+
+  const _Dettaglio(this.label, this.valore);
+
+  @override
+  Widget build(BuildContext context) {
+    if (valore.isEmpty) return const SizedBox.shrink();
+    return RichText(
+      text: TextSpan(
+        style: DefaultTextStyle.of(context).style.copyWith(fontSize: 12),
+        children: [
+          TextSpan(
+            text: '$label: ',
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          TextSpan(text: valore),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Nuova schermata `SpellCardsScreen`: ricerca un incantesimo per nome (riusa `JsonDataRepository.searchSpells`) e lo aggiunge a un mazzo di card sintetiche consultabili durante la sessione
- Nuovo widget riutilizzabile `SpellCard`: nome, livello/scuola, tempo di lancio, raggio, componenti, durata, classi e descrizione
- Funziona sia per gli incantesimi di un PG che per quelli di un mostro/PNG (il Master cerca per nome quello che gli serve, senza dover scorrere l'intero database)
- Raggiungibile dalla toolbar del tracker di combattimento (icona libro) e dalla sezione Incantesimi della scheda di un personaggio salvato

Nota: v1 solo vista in-app (no export PDF), come da nota nell'issue ("da valutare... o entrambi") — l'export PDF può essere aggiunto in un secondo momento se serve davvero.

Chiude #7

## Test plan
- [x] `flutter analyze` pulito
- [x] `flutter test` verde
- [x] `flutter build web` completato senza errori