### PR TITLE
Rimuove 81 incantesimi duplicati in spells.json

### DIFF
--- a/assets/data/spells.json
+++ b/assets/data/spells.json
@@ -10,7 +10,7 @@
     "Acquisitions Inc",
     "System Reference Document"
   ],
-  "total_spells": 407,
+  "total_spells": 326,
   "spells": [
     {
       "id": "acid_splash",
@@ -2168,114 +2168,6 @@
       "source": "Player's Handbook"
     },
     {
-      "id": "acid_arrow",
-      "nome": "Acid Arrow",
-      "livello": 2,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "27 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Druido",
-        "Mago"
-      ],
-      "descrizione": "A shimmering green arrow streaks toward a target within range and bursts in a spray of acid. Make a ranged spell attack against the target. On a hit, the target takes 4d4 acid damage immediately and 2d4 acid damage at the end of its next turn. On a miss, the arrow splashes the target with acid for half as much of the initial damage and no damage at the end of its next turn.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 3rd level or higher, the damage (both initial and later) increases by 1d4 for each slot level above 2nd.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "acid_splash",
-      "nome": "Acid Splash",
-      "livello": 0,
-      "scuola": "Invocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "18 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "You hurl a bubble of acid. Choose one creature within range, or choose two creatures within range that are within 5 feet of each other. A target must succeed on a dexterity saving throw or take 1d6 acid damage.",
-      "eTrucchetto": true,
-      "scaling": "This spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "aid",
-      "nome": "Aid",
-      "livello": 2,
-      "scuola": "Abjurazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "9 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "8 ore",
-      "classi": [
-        "Chierico",
-        "Paladino"
-      ],
-      "descrizione": "Your spell bolsters your allies with toughness and resolve. Choose up to three creatures within range. Each target's hit point maximum and current hit points increase by 5 for the duration.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 3rd level or higher, a target's hit points increase by an additional 5 for each slot level above 2nd.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "alarm",
-      "nome": "Alarm",
-      "livello": 1,
-      "scuola": "Abjurazione",
-      "tempo_lancio": "1 minuto",
-      "raggio": "9 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "8 ore",
-      "classi": [
-        "Ranger",
-        "Mago"
-      ],
-      "descrizione": "You set an alarm against unwanted intrusion. Choose a door, a window, or an area within range that is no larger than a 20-foot cube. Until the spell ends, an alarm alerts you whenever a Tiny or larger creature touches or enters the warded area. \n\nWhen you cast the spell, you can designate creatures that won't set off the alarm. You also choose whether the alarm is mental or audible. A mental alarm alerts you with a ping in your mind if you are within 1 mile of the warded area. This ping awakens you if you are sleeping. An audible alarm produces the sound of a hand bell for 10 seconds within 60 feet.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "alter_self",
-      "nome": "Alter Self",
-      "livello": 2,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Fino a 1 ora",
-      "classi": [
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "You assume a different form. When you cast the spell, choose one of the following options, the effects of which last for the duration of the spell. While the spell lasts, you can end one option as an action to gain the benefits of a different one.\n\n**Aquatic Adaptation.** You adapt your body to an aquatic environment, sprouting gills and growing webbing between your fingers. You can breathe underwater and gain a swimming speed equal to your walking speed.\n\n**Change Appearance.** You transform your appearance. You decide what you look like, including your height, weight, facial features, sound of your voice, hair length, coloration, and distinguishing characteristics, if any. You can make yourself appear as a member of another race, though none of your statistics change. You also can't appear as a creature of a different size than you, and your basic shape stays the same; if you're bipedal, you can't use this spell to become quadrupedal, for instance. At any time for the duration of the spell, you can use your action to change your appearance in this way again.\n\n**Natural Weapons.** You grow claws, fangs, spines, horns, or a different natural weapon of your choice. Your unarmed strikes deal 1d6 bludgeoning, piercing, or slashing damage, as appropriate to the natural weapon you chose, and you are proficient with your unarmed strikes. Finally, the natural weapon is magic and you have a +1 bonus to the attack and damage rolls you make using it.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "animal_friendship",
       "nome": "Animal Friendship",
       "livello": 1,
@@ -2493,27 +2385,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "arcane_lock",
-      "nome": "Arcane Lock",
-      "livello": 2,
-      "scuola": "Abjurazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a quando non viene dissolto",
-      "classi": [
-        "Mago"
-      ],
-      "descrizione": "You touch a closed door, window, gate, chest, or other entryway, and it becomes locked for the duration. You and the creatures you designate when you cast this spell can open the object normally. You can also set a password that, when spoken within 5 feet of the object, suppresses this spell for 1 minute. Otherwise, it is impassable until it is broken or the spell is dispelled or suppressed. Casting knock on the object suppresses arcane lock for 10 minutes. While affected by this spell, the object is more difficult to break or force open; the DC to break it or pick any locks on it increases by 10.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "arcane_sword",
       "nome": "Arcane Sword",
       "livello": 7,
@@ -2623,29 +2494,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "bane",
-      "nome": "Bane",
-      "livello": 1,
-      "scuola": "Ammaliamento",
-      "tempo_lancio": "1 azione",
-      "raggio": "9 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 minuto",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Paladino"
-      ],
-      "descrizione": "Up to three creatures of your choice that you can see within range must make charisma saving throws. Whenever a target that fails this saving throw makes an attack roll or a saving throw before the spell ends, the target must roll a d4 and subtract the number rolled from the attack roll or saving throw.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 2nd level or higher, you can target one additional creature for each slot level above 1st.",
-      "source": "System Reference Document"
-    },
-    {
       "id": "banishment",
       "nome": "Banishment",
       "livello": 4,
@@ -2668,29 +2516,6 @@
       "descrizione": "You attempt to send one creature that you can see within range to another plane of existence. The target must succeed on a charisma saving throw or be banished. If the target is native to the plane of existence you're on, you banish the target to a harmless demiplane. While there, the target is incapacitated. The target remains there until the spell ends, at which point the target reappears in the space it left or in the nearest unoccupied space if that space is occupied. If the target is native to a different plane of existence than the one you're on, the target is banished with a faint popping noise, returning to its home plane. If the spell ends before 1 minute has passed, the target reappears in the space it left or in the nearest unoccupied space if that space is occupied. Otherwise, the target doesn't return.",
       "eTrucchetto": false,
       "scaling": "When you cast this spell using a spell slot of 5th level or higher, you can target one additional creature for each slot level above 4th.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "barkskin",
-      "nome": "Barkskin",
-      "livello": 2,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 ora",
-      "classi": [
-        "Chierico",
-        "Druido",
-        "Ranger"
-      ],
-      "descrizione": "You touch a willing creature. Until the spell ends, the target's skin has a rough, bark-like appearance, and the target's AC can't be less than 16, regardless of what kind of armor it is wearing.",
-      "eTrucchetto": false,
-      "scaling": null,
       "source": "System Reference Document"
     },
     {
@@ -2779,28 +2604,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "bless",
-      "nome": "Bless",
-      "livello": 1,
-      "scuola": "Ammaliamento",
-      "tempo_lancio": "1 azione",
-      "raggio": "9 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 minuto",
-      "classi": [
-        "Chierico",
-        "Paladino"
-      ],
-      "descrizione": "You bless up to three creatures of your choice within range. Whenever a target makes an attack roll or a saving throw before the spell ends, the target can roll a d4 and add the number rolled to the attack roll or saving throw.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 2nd level or higher, you can target one additional creature for each slot level above 1st.",
-      "source": "System Reference Document"
-    },
-    {
       "id": "blight",
       "nome": "Blight",
       "livello": 4,
@@ -2870,27 +2673,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "blur",
-      "nome": "Blur",
-      "livello": 2,
-      "scuola": "Illusione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V"
-      ],
-      "durata": "Fino a 1 minuto",
-      "classi": [
-        "Druido",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "Your body becomes blurred, shifting and wavering to all who can see you. For the duration, any creature has disadvantage on attack rolls against you. An attacker is immune to this effect if it doesn't rely on sight, as with blindsight, or can see through illusions, as with truesight.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "branding_smite",
       "nome": "Branding Smite",
       "livello": 2,
@@ -2907,29 +2689,6 @@
       "descrizione": "The next time you hit a creature with a weapon attack before this spell ends, the weapon gleams with astral radiance as you strike. The attack deals an extra 2d6 radiant damage to the target, which becomes visible if it's invisible, and the target sheds dim light in a 5-­--foot radius and can't become invisible until the spell ends.",
       "eTrucchetto": false,
       "scaling": "When you cast this spell using a spell slot of 3rd level or higher, the extra damage increases by 1d6 for each slot level above 2nd.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "burning_hands",
-      "nome": "Burning Hands",
-      "livello": 1,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Chierico",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "As you hold your hands with thumbs touching and fingers spread, a thin sheet of flames shoots forth from your outstretched fingertips. Each creature in a 15-foot cone must make a dexterity saving throw. A creature takes 3d6 fire damage on a failed save, or half as much damage on a successful one. The fire ignites any flammable objects in the area that aren't being worn or carried.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.",
       "source": "System Reference Document"
     },
     {
@@ -2954,28 +2713,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "calm_emotions",
-      "nome": "Calm Emotions",
-      "livello": 2,
-      "scuola": "Ammaliamento",
-      "tempo_lancio": "1 azione",
-      "raggio": "18 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Fino a 1 minuto",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Warlock"
-      ],
-      "descrizione": "You attempt to suppress strong emotions in a group of people. Each humanoid in a 20-foot-radius sphere centered on a point you choose within range must make a charisma saving throw; a creature can choose to fail this saving throw if it wishes. If a creature fails its saving throw, choose one of the following two effects. You can suppress any effect causing a target to be charmed or frightened. When this spell ends, any suppressed effect resumes, provided that its duration has not expired in the meantime. Alternatively, you can make a target indifferent about creatures of your choice that it is hostile toward. This indifference ends if the target is attacked or harmed by a spell or if it witnesses any of its friends being harmed. When the spell ends, the creature becomes hostile again, unless the DM rules otherwise.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "chain_lightning",
       "nome": "Chain Lightning",
       "livello": 6,
@@ -2995,53 +2732,6 @@
       "descrizione": "You create a bolt of lightning that arcs toward a target of your choice that you can see within range. Three bolts then leap from that target to as many as three other targets, each of which must be within 30 feet of the first target. A target can be a creature or an object and can be targeted by only one of the bolts. A target must make a dexterity saving throw. The target takes 10d8 lightning damage on a failed save, or half as much damage on a successful one.",
       "eTrucchetto": false,
       "scaling": "When you cast this spell using a spell slot of 7th level or higher, one additional bolt leaps from the first target to another target for each slot level above 6th.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "charm_person",
-      "nome": "Charm Person",
-      "livello": 1,
-      "scuola": "Ammaliamento",
-      "tempo_lancio": "1 azione",
-      "raggio": "9 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "1 ora",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Druido",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "You attempt to charm a humanoid you can see within range. It must make a wisdom saving throw, and does so with advantage if you or your companions are fighting it. If it fails the saving throw, it is charmed by you until the spell ends or until you or your companions do anything harmful to it. The charmed creature regards you as a friendly acquaintance. When the spell ends, the creature knows it was charmed by you.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 2nd level or higher, you can target one additional creature for each slot level above 1st. The creatures must be within 30 feet of each other when you target them.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "chill_touch",
-      "nome": "Chill Touch",
-      "livello": 0,
-      "scuola": "Necromanzia",
-      "tempo_lancio": "1 azione",
-      "raggio": "36 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "1 round",
-      "classi": [
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "You create a ghostly, skeletal hand in the space of a creature within range. Make a ranged spell attack against the creature to assail it with the chill of the grave. On a hit, the target takes 1d8 necrotic damage, and it can't regain hit points until the start of your next turn. Until then, the hand clings to the target. If you hit an undead target, it also has disadvantage on attack rolls against you until the end of your next turn.",
-      "eTrucchetto": true,
-      "scaling": "This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
       "source": "System Reference Document"
     },
     {
@@ -3504,28 +3194,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "continual_flame",
-      "nome": "Continual Flame",
-      "livello": 2,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a quando non viene dissolto",
-      "classi": [
-        "Chierico",
-        "Mago"
-      ],
-      "descrizione": "A flame, equivalent in brightness to a torch, springs forth from an object that you touch. The effect looks like a regular flame, but it creates no heat and doesn't use oxygen. A continual flame can be covered or hidden but not smothered or quenched.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "control_water",
       "nome": "Control Water",
       "livello": 4,
@@ -3683,53 +3351,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "cure_wounds",
-      "nome": "Cure Wounds",
-      "livello": 1,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Druido",
-        "Paladino",
-        "Ranger"
-      ],
-      "descrizione": "A creature you touch regains a number of hit points equal to 1d8 + your spellcasting ability modifier. This spell has no effect on undead or constructs.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 2nd level or higher, the healing increases by 1d8 for each slot level above 1st.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "dancing_lights",
-      "nome": "Dancing Lights",
-      "livello": 0,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "36 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 minuto",
-      "classi": [
-        "Bardo",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "You create up to four torch-sized lights within range, making them appear as torches, lanterns, or glowing orbs that hover in the air for the duration. You can also combine the four lights into one glowing vaguely humanoid form of Medium size. Whichever form you choose, each light sheds dim light in a 10-foot radius. As a bonus action on your turn, you can move the lights up to 60 feet to a new spot within range. A light must be within 20 feet of another light created by this spell, and a light winks out if it exceeds the spell's range.",
-      "eTrucchetto": true,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "darkness",
       "nome": "Darkness",
       "livello": 2,
@@ -3748,30 +3369,6 @@
         "Mago"
       ],
       "descrizione": "Magical darkness spreads from a point you choose within range to fill a 15-foot-radius sphere for the duration. The darkness spreads around corners. A creature with darkvision can't see through this darkness, and nonmagical light can't illuminate it. If the point you choose is on an object you are holding or one that isn't being worn or carried, the darkness emanates from the object and moves with it. Completely covering the source of the darkness with an opaque object, such as a bowl or a helm, blocks the darkness. If any of this spell's area overlaps with an area of light created by a spell of 2nd level or lower, the spell that created the light is dispelled.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "darkvision",
-      "nome": "Darkvision",
-      "livello": 2,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "8 ore",
-      "classi": [
-        "Druido",
-        "Ranger",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "You touch a willing creature to grant it the ability to see in the dark. For the duration, that creature has darkvision out to a range of 60 feet.",
       "eTrucchetto": false,
       "scaling": null,
       "source": "System Reference Document"
@@ -3885,32 +3482,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "detect_magic",
-      "nome": "Detect Magic",
-      "livello": 1,
-      "scuola": "Divinazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Fino a 10 minuti",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Druido",
-        "Paladino",
-        "Ranger",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "For the duration, you sense the presence of magic within 30 feet of you. If you sense magic in this way, you can use your action to see a faint aura around any visible creature or object in the area that bears magic, and you learn its school of magic, if any. The spell can penetrate most barriers, but it is blocked by 1 foot of stone, 1 inch of common metal, a thin sheet of lead, or 3 feet of wood or dirt.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "detect_poison_and_disease",
       "nome": "Detect Poison and Disease",
       "livello": 1,
@@ -3935,30 +3506,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "detect_thoughts",
-      "nome": "Detect Thoughts",
-      "livello": 2,
-      "scuola": "Divinazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 minuto",
-      "classi": [
-        "Bardo",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "For the duration, you can read the thoughts of certain creatures. When you cast the spell and as your action on each turn until the spell ends, you can focus your mind on any one creature that you can see within 30 feet of you. If the creature you choose has an Intelligence of 3 or lower or doesn't speak any language, the creature is unaffected. You initially learn the surface thoughts of the creature-what is most on its mind in that moment. As an action, you can either shift your attention to another creature's thoughts or attempt to probe deeper into the same creature's mind. If you probe deeper, the target must make a Wisdom saving throw. If it fails, you gain insight into its reasoning (if any), its emotional state, and something that looms large in its mind (such as something it worries over, loves, or hates). If it succeeds, the spell ends. Either way, the target knows that you are probing into its mind, and unless you shift your attention to another creature's thoughts, the creature can use its action on its turn to make an Intelligence check contested by your Intelligence check; if it succeeds, the spell ends. Questions verbally directed at the target creature naturally shape the course of its thoughts, so this spell is particularly effective as part of an interrogation. You can also use this spell to detect the presence of thinking creatures you can't see. When you cast the spell or as your action during the duration, you can search for thoughts within 30 feet of you. The spell can penetrate barriers, but 2 feet of rock, 2 inches of any metal other than lead, or a thin sheet of lead blocks you. You can't detect a creature with an Intelligence of 3 or lower or one that doesn't speak any language. Once you detect the presence of a creature in this way, you can read its thoughts for the rest of the duration as described above, even if you can't see it, but it must still be within range.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "dimension_door",
       "nome": "Dimension Door",
       "livello": 4,
@@ -3978,29 +3525,6 @@
         "Mago"
       ],
       "descrizione": "You teleport yourself from your current location to any other spot within range. You arrive at exactly the spot desired. It can be a place you can see, one you can visualize, or one you can describe by stating distance and direction, such as \"200 feet straight downward\" or \"upward to the northwest at a 45-degree angle, 300 feet.\" You can bring along objects as long as their weight doesn't exceed what you can carry. You can also bring one willing creature of your size or smaller who is carrying gear up to its carrying capacity. The creature must be within 5 feet of you when you cast this spell. If you would arrive in a place already occupied by an object or a creature, you and any creature traveling with you each take 4d6 force damage, and the spell fails to teleport you.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "disguise_self",
-      "nome": "Disguise Self",
-      "livello": 1,
-      "scuola": "Illusione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "1 ora",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "You make yourself - including your clothing, armor, weapons, and other belongings on your person - look different until the spell ends or until you use your action to dismiss it. You can seem 1 foot shorter or taller and can appear thin, fat, or in between. You can't change your body type, so you must adopt a form that has the same basic arrangement of limbs. Otherwise, the extent of the illusion is up to you. The changes wrought by this spell fail to hold up to physical inspection. For example, if you use this spell to add a hat to your outfit, objects pass through the hat, and anyone who touches it would feel nothing or would feel your head and hair. If you use this spell to appear thinner than you are, the hand of someone who reaches out to touch you would bump into you while it was seemingly still in midair. To discern that you are disguised, a creature can use its action to inspect your apperance and must succeed on an Intelligence (Investigation) check against your spell save DC.",
       "eTrucchetto": false,
       "scaling": null,
       "source": "System Reference Document"
@@ -4232,26 +3756,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "druidcraft",
-      "nome": "Druidcraft",
-      "livello": 0,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "9 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Druido"
-      ],
-      "descrizione": "Whispering to the spirits of nature, you create one of the following effects within range: \n- You create a tiny, harmless sensory effect that predicts what the weather will be at your location for the next 24 hours. The effect might manifest as a golden orb for clear skies, a cloud for rain, falling snowflakes for snow, and so on. This effect persists for 1 round. \n- You instantly make a flower blossom, a seed pod open, or a leaf bud bloom. \n- You create an instantaneous, harmless sensory effect, such as falling leaves, a puff of wind, the sound of a small animal, or the faint odor of skunk. The effect must fit in a 5-­--foot cube. \n- You instantly light or snuff out a candle, a torch, or a small campfire.",
-      "eTrucchetto": true,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "earthquake",
       "nome": "Earthquake",
       "livello": 8,
@@ -4272,50 +3776,6 @@
       "descrizione": "You create a seismic disturbance at a point on the ground that you can see within range. For the duration, an intense tremor rips through the ground in a 100-foot-radius circle centered on that point and shakes creatures and structures in contact with the ground in that area. The ground in the area becomes difficult terrain. Each creature on the ground that is concentrating must make a constitution saving throw. On a failed save, the creature's concentration is broken. When you cast this spell and at the end of each turn you spend concentrating on it, each creature on the ground in the area must make a dexterity saving throw. On a failed save, the creature is knocked prone. This spell can have additional effects depending on the terrain in the area, as determined by the DM. \n\n**Fissures.** Fissures open throughout the spell's area at the start of your next turn after you cast the spell. A total of 1d6 such fissures open in locations chosen by the DM. Each is 1d10 × 10 feet deep, 10 feet wide, and extends from one edge of the spell's area to the opposite side. A creature standing on a spot where a fissure opens must succeed on a dexterity saving throw or fall in. A creature that successfully saves moves with the fissure's edge as it opens. A fissure that opens beneath a structure causes it to automatically collapse (see below). \n\n**Structures.** The tremor deals 50 bludgeoning damage to any structure in contact with the ground in the area when you cast the spell and at the start of each of your turns until the spell ends. If a structure drops to 0 hit points, it collapses and potentially damages nearby creatures. A creature within half the distance of a structure's height must make a dexterity saving throw. On a failed save, the creature takes 5d6 bludgeoning damage, is knocked prone, and is buried in the rubble, requiring a DC 20 Strength (Athletics) check as an action to escape. The DM can adjust the DC higher or lower, depending on the nature of the rubble. On a successful save, the creature takes half as much damage and doesn't fall prone or become buried.",
       "eTrucchetto": false,
       "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "eldritch_blast",
-      "nome": "Eldritch Blast",
-      "livello": 0,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "36 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Warlock"
-      ],
-      "descrizione": "A beam of crackling energy streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 force damage. The spell creates more than one beam when you reach higher levels: two beams at 5th level, three beams at 11th level, and four beams at 17th level. You can direct the beams at the same target or at different ones. Make a separate attack roll for each beam.",
-      "eTrucchetto": true,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "enhance_ability",
-      "nome": "Enhance Ability",
-      "livello": 2,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 ora",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Druido",
-        "Stregone"
-      ],
-      "descrizione": "You touch a creature and bestow upon it a magical enhancement. Choose one of the following effects; the target gains that effect until the spell ends.\n\n**Bear's Endurance.** The target has advantage on constitution checks. It also gains 2d6 temporary hit points, which are lost when the spell ends.\n\n**Bull's Strength.** The target has advantage on strength checks, and his or her carrying capacity doubles.\n\n**Cat's Grace.** The target has advantage on dexterity checks. It also doesn't take damage from falling 20 feet or less if it isn't incapacitated.\n\n**Eagle's Splendor.** The target has advantage on Charisma checks\n\n **Fox's Cunning.** The target has advantage on intelligence checks.\n\n**Owl's Wisdom.** The target has advantage on wisdom checks.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 3rd level or higher, you can target one additional creature for each slot level above 2nd.",
       "source": "System Reference Document"
     },
     {
@@ -4514,28 +3974,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "false_life",
-      "nome": "False Life",
-      "livello": 1,
-      "scuola": "Necromanzia",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "1 ora",
-      "classi": [
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "Bolstering yourself with a necromantic facsimile of life, you gain 1d4 + 4 temporary hit points for the duration.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 2nd level or higher, you gain 5 additional temporary hit points for each slot level above 1st.",
-      "source": "System Reference Document"
-    },
-    {
       "id": "fear",
       "nome": "Fear",
       "livello": 3,
@@ -4555,28 +3993,6 @@
         "Mago"
       ],
       "descrizione": "You project a phantasmal image of a creature's worst fears. Each creature in a 30-foot cone must succeed on a wisdom saving throw or drop whatever it is holding and become frightened for the duration. While frightened by this spell, a creature must take the Dash action and move away from you by the safest available route on each of its turns, unless there is nowhere to move. If the creature ends its turn in a location where it doesn't have line of sight to you, the creature can make a wisdom saving throw. On a successful save, the spell ends for that creature.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "feather_fall",
-      "nome": "Feather Fall",
-      "livello": 1,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 reazione",
-      "raggio": "18 metri",
-      "componenti": [
-        "V",
-        "M"
-      ],
-      "durata": "1 minuto",
-      "classi": [
-        "Bardo",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "Choose up to five falling creatures within range. A falling creature's rate of descent slows to 60 feet per round until the spell ends. If the creature lands before the spell ends, it takes no falling damage and can land on its feet, and the spell ends for that creature.",
       "eTrucchetto": false,
       "scaling": null,
       "source": "System Reference Document"
@@ -4714,27 +4130,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "fire_bolt",
-      "nome": "Fire Bolt",
-      "livello": 0,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "36 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "You hurl a mote of fire at a creature or object within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 fire damage. A flammable object hit by this spell ignites if it isn't being worn or carried.",
-      "eTrucchetto": true,
-      "scaling": "This spell's damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10).",
-      "source": "System Reference Document"
-    },
-    {
       "id": "fire_shield",
       "nome": "Fire Shield",
       "livello": 4,
@@ -4845,29 +4240,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "flaming_sphere",
-      "nome": "Flaming Sphere",
-      "livello": 2,
-      "scuola": "Invocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "18 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 minuto",
-      "classi": [
-        "Chierico",
-        "Druido",
-        "Mago"
-      ],
-      "descrizione": "A 5-foot-diameter sphere of fire appears in an unoccupied space of your choice within range and lasts for the duration. Any creature that ends its turn within 5 feet of the sphere must make a dexterity saving throw. The creature takes 2d6 fire damage on a failed save, or half as much damage on a successful one. As a bonus action, you can move the sphere up to 30 feet. If you ram the sphere into a creature, that creature must make the saving throw against the sphere's damage, and the sphere stops moving this turn. When you move the sphere, you can direct it over barriers up to 5 feet tall and jump it across pits up to 10 feet wide. The sphere ignites flammable objects not being worn or carried, and it sheds bright light in a 20-foot radius and dim light for an additional 20 feet.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d6 for each slot level above 2nd.",
-      "source": "System Reference Document"
-    },
-    {
       "id": "flesh_to_stone",
       "nome": "Flesh to Stone",
       "livello": 6,
@@ -4931,30 +4303,6 @@
       "descrizione": "You touch a willing creature. The target gains a flying speed of 60 feet for the duration. When the spell ends, the target falls if it is still aloft, unless it can stop the fall.",
       "eTrucchetto": false,
       "scaling": "When you cast this spell using a spell slot of 4th level or higher, you can target one additional creature for each slot level above 3rd.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "fog_cloud",
-      "nome": "Fog Cloud",
-      "livello": 1,
-      "scuola": "Invocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "36 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Fino a 1 ora",
-      "classi": [
-        "Chierico",
-        "Druido",
-        "Ranger",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "You create a 20-foot-radius sphere of fog centered on a point within range. The sphere spreads around corners, and its area is heavily obscured. It lasts for the duration or until a wind of moderate or greater speed (at least 10 miles per hour) disperses it.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 2nd level or higher, the radius of the fog increases by 20 feet for each slot level above 1st.",
       "source": "System Reference Document"
     },
     {
@@ -5142,28 +4490,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "gentle_repose",
-      "nome": "Gentle Repose",
-      "livello": 2,
-      "scuola": "Necromanzia",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "10 giorni",
-      "classi": [
-        "Chierico",
-        "Mago"
-      ],
-      "descrizione": "You touch a corpse or other remains. For the duration, the target is protected from decay and can't become undead. The spell also effectively extends the time limit on raising the target from the dead, since days spent under the influence of this spell don't count against the time limit of spells such as raise dead.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "giant_insect",
       "nome": "Giant Insect",
       "livello": 4,
@@ -5246,49 +4572,6 @@
       "descrizione": "When you cast this spell, you inscribe a glyph that harms other creatures, either upon a surface (such as a table or a section of floor or wall) or within an object that can be closed (such as a book, a scroll, or a treasure chest) to conceal the glyph. If you choose a surface, the glyph can cover an area of the surface no larger than 10 feet in diameter. If you choose an object, that object must remain in its place; if the object is moved more than 10 feet from where you cast this spell, the glyph is broken, and the spell ends without being triggered. The glyph is nearly invisible and requires a successful Intelligence (Investigation) check against your spell save DC to be found. You decide what triggers the glyph when you cast the spell. For glyphs inscribed on a surface, the most typical triggers include touching or standing on the glyph, removing another object covering the glyph, approaching within a certain distance of the glyph, or manipulating the object on which the glyph is inscribed. For glyphs inscribed within an object, the most common triggers include opening that object, approaching within a certain distance of the object, or seeing or reading the glyph. Once a glyph is triggered, this spell ends. You can further refine the trigger so the spell activates only under certain circumstances or according to physical characteristics (such as height or weight), creature kind (for example, the ward could be set to affect aberrations or drow), or alignment. You can also set conditions for creatures that don't trigger the glyph, such as those who say a certain password. When you inscribe the glyph, choose explosive runes or a spell glyph.\n\n**Explosive Runes.** When triggered, the glyph erupts with magical energy in a 20-­foot-­radius sphere centered on the glyph. The sphere spreads around corners. Each creature in the area must make a Dexterity saving throw. A creature takes 5d8 acid, cold, fire, lightning, or thunder damage on a failed saving throw (your choice when you create the glyph), or half as much damage on a successful one.\n\n**Spell Glyph.** You can store a prepared spell of 3rd level or lower in the glyph by casting it as part of creating the glyph. The spell must target a single creature or an area. The spell being stored has no immediate effect when cast in this way. When the glyph is triggered, the stored spell is cast. If the spell has a target, it targets the creature that triggered the glyph. If the spell affects an area, the area is centered on that creature. If the spell summons hostile creatures or creates harmful objects or traps, they appear as close as possible to the intruder and attack it. If the spell requires concentration, it lasts until the end of its full duration.",
       "eTrucchetto": false,
       "scaling": "When you cast this spell using a spell slot of 4th level or higher, the damage of an explosive runes glyph increases by 1d8 for each slot level above 3rd. If you create a spell glyph, you can store any spell of up to the same level as the slot you use for the glyph of warding.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "goodberry",
-      "nome": "Goodberry",
-      "livello": 1,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Druido",
-        "Ranger"
-      ],
-      "descrizione": "Up to ten berries appear in your hand and are infused with magic for the duration. A creature can use its action to eat one berry. Eating a berry restores 1 hit point, and the berry provides enough nourishment to sustain a creature for one day. The berries lose their potency if they have not been consumed within 24 hours of the casting of this spell.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "grease",
-      "nome": "Grease",
-      "livello": 1,
-      "scuola": "Invocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "18 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "1 minuto",
-      "classi": [
-        "Mago"
-      ],
-      "descrizione": "Slick grease covers the ground in a 10-foot square centered on a point within range and turns it into difficult terrain for the duration. When the grease appears, each creature standing in its area must succeed on a dexterity saving throw or fall prone. A creature that enters the area or ends its turn there must also succeed on a dexterity saving throw or fall prone.",
-      "eTrucchetto": false,
-      "scaling": null,
       "source": "System Reference Document"
     },
     {
@@ -5380,27 +4663,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "guidance",
-      "nome": "Guidance",
-      "livello": 0,
-      "scuola": "Divinazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Fino a 1 minuto",
-      "classi": [
-        "Chierico",
-        "Druido"
-      ],
-      "descrizione": "You touch one willing creature. Once before the spell ends, the target can roll a d4 and add the number rolled to one ability check of its choice. It can roll the die before or after making the ability check. The spell then ends.",
-      "eTrucchetto": true,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "guiding_bolt",
       "nome": "Guiding Bolt",
       "livello": 1,
@@ -5418,30 +4680,6 @@
       "descrizione": "A flash of light streaks toward a creature of your choice within range. Make a ranged spell attack against the target. On a hit, the target takes 4d6 radiant damage, and the next attack roll made against this target before the end of your next turn has advantage, thanks to the mystical dim light glittering on the target until then.",
       "eTrucchetto": false,
       "scaling": "When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d6 for each slot level above 1st.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "gust_of_wind",
-      "nome": "Gust of Wind",
-      "livello": 2,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 minuto",
-      "classi": [
-        "Chierico",
-        "Druido",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "A line of strong wind 60 feet long and 10 feet wide blasts from you in a direction you choose for the spell's duration. Each creature that starts its turn in the line must succeed on a strength saving throw or be pushed 15 feet away from you in a direction following the line. Any creature in the line must spend 2 feet of movement for every 1 foot it moves when moving closer to you. The gust disperses gas or vapor, and it extinguishes candles, torches, and similar unprotected flames in the area. It causes protected flames, such as those of lanterns, to dance wildly and has a 50 percent chance to extinguish them. As a bonus action on each of your turns before the spell ends, you can change the direction in which the line blasts from you.",
-      "eTrucchetto": false,
-      "scaling": null,
       "source": "System Reference Document"
     },
     {
@@ -5553,49 +4791,6 @@
       "descrizione": "Choose a creature that you can see within range. A surge of positive energy washes through the creature, causing it to regain 70 hit points. This spell also ends blindness, deafness, and any diseases affecting the target. This spell has no effect on constructs or undead.",
       "eTrucchetto": false,
       "scaling": "When you cast this spell using a spell slot of 7th level or higher, the amount of healing increases by 10 for each slot level above 6th.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "healing_word",
-      "nome": "Healing Word",
-      "livello": 1,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione bonus",
-      "raggio": "18 metri",
-      "componenti": [
-        "V"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Druido"
-      ],
-      "descrizione": "A creature of your choice that you can see within range regains hit points equal to 1d4 + your spellcasting ability modifier. This spell has no effect on undead or constructs.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 2nd level or higher, the healing increases by 1d4 for each slot level above 1st.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "heat_metal",
-      "nome": "Heat Metal",
-      "livello": 2,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "18 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 minuto",
-      "classi": [
-        "Bardo",
-        "Druido"
-      ],
-      "descrizione": "Choose a manufactured metal object, such as a metal weapon or a suit of heavy or medium metal armor, that you can see within range. You cause the object to glow red-hot. Any creature in physical contact with the object takes 2d8 fire damage when you cast the spell. Until the spell ends, you can use a bonus action on each of your subsequent turns to cause this damage again. If a creature is holding or wearing the object and takes the damage from it, the creature must succeed on a constitution saving throw or drop the object if it can. If it doesn't drop the object, it has disadvantage on attack rolls and ability checks until the start of your next turn.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd.",
       "source": "System Reference Document"
     },
     {
@@ -5712,33 +4907,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "hold_person",
-      "nome": "Hold Person",
-      "livello": 2,
-      "scuola": "Ammaliamento",
-      "tempo_lancio": "1 azione",
-      "raggio": "18 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 minuto",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Druido",
-        "Paladino",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "Choose a humanoid that you can see within range. The target must succeed on a wisdom saving throw or be paralyzed for the duration. At the end of each of its turns, the target can make another wisdom saving throw. On a success, the spell ends on the target.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 3rd level or higher, you can target one additional humanoid for each slot level above 2nd. The humanoids must be within 30 feet of each other when you target them.",
-      "source": "System Reference Document"
-    },
-    {
       "id": "holy_aura",
       "nome": "Holy Aura",
       "livello": 8,
@@ -5757,26 +4925,6 @@
       "descrizione": "Divine light washes out from you and coalesces in a soft radiance in a 30-foot radius around you. Creatures of your choice in that radius when you cast this spell shed dim light in a 5-foot radius and have advantage on all saving throws, and other creatures have disadvantage on attack rolls against them until the spell ends. In addition, when a fiend or an undead hits an affected creature with a melee attack, the aura flashes with brilliant light. The attacker must succeed on a constitution saving throw or be blinded until the spell ends.",
       "eTrucchetto": false,
       "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "hunters_mark",
-      "nome": "Hunter's Mark",
-      "livello": 1,
-      "scuola": "Divinazione",
-      "tempo_lancio": "1 azione bonus",
-      "raggio": "27 metri",
-      "componenti": [
-        "V"
-      ],
-      "durata": "Fino a 1 ora",
-      "classi": [
-        "Paladino",
-        "Ranger"
-      ],
-      "descrizione": "You choose a creature you can see within range and mystically mark it as your quarry. Until the spell ends, you deal an extra 1d6 damage to the target whenever you hit it with a weapon attack, and you have advantage on any Wisdom (Perception) or Wisdom (Survival) check you make to find it. If the target drops to 0 hit points before this spell ends, you can use a bonus action on a subsequent turn of yours to mark a new creature.",
-      "eTrucchetto": false,
-      "scaling": " When you cast this spell using a spell slot of 3rd or 4th level, you can maintain your concentration on the spell for up to 8 hours. When you use a spell slot of 5th level or higher, you can maintain your concentration on the spell for up to 24 hours.",
       "source": "System Reference Document"
     },
     {
@@ -5825,29 +4973,6 @@
       "descrizione": "A hail of rock-hard ice pounds to the ground in a 20-foot-radius, 40-foot-high cylinder centered on a point within range. Each creature in the cylinder must make a dexterity saving throw. A creature takes 2d8 bludgeoning damage and 4d6 cold damage on a failed save, or half as much damage on a successful one. Hailstones turn the storm's area of effect into difficult terrain until the end of your next turn.",
       "eTrucchetto": false,
       "scaling": "When you cast this spell using a spell slot of 5th level or higher, the bludgeoning damage increases by 1d8 for each slot level above 4th.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "identify",
-      "nome": "Identify",
-      "livello": 1,
-      "scuola": "Divinazione",
-      "tempo_lancio": "1 minuto",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Mago"
-      ],
-      "descrizione": "You choose one object that you must touch throughout the casting of the spell. If it is a magic item or some other magic-imbued object, you learn its properties and how to use them, whether it requires attunement to use, and how many charges it has, if any. You learn whether any spells are affecting the item and what they are. If the item was created by a spell, you learn which spell created it. If you instead touch a creature throughout the casting, you learn what spells, if any, are currently affecting it.",
-      "eTrucchetto": false,
-      "scaling": null,
       "source": "System Reference Document"
     },
     {
@@ -5980,31 +5105,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "invisibility",
-      "nome": "Invisibility",
-      "livello": 2,
-      "scuola": "Illusione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 ora",
-      "classi": [
-        "Bardo",
-        "Druido",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "A creature you touch becomes invisible until the spell ends. Anything the target is wearing or carrying is invisible as long as it is on the target's person. The spell ends for a target that attacks or casts a spell.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 3rd level or higher, you can target one additional creature for each slot level above 2nd.",
-      "source": "System Reference Document"
-    },
-    {
       "id": "irresistible_dance",
       "nome": "Irresistible Dance",
       "livello": 6,
@@ -6020,51 +5120,6 @@
         "Mago"
       ],
       "descrizione": "Choose one creature that you can see within range. The target begins a comic dance in place: shuffling, tapping its feet, and capering for the duration. Creatures that can't be charmed are immune to this spell. A dancing creature must use all its movement to dance without leaving its space and has disadvantage on dexterity saving throws and attack rolls. While the target is affected by this spell, other creatures have advantage on attack rolls against it. As an action, a dancing creature makes a wisdom saving throw to regain control of itself. On a successful save, the spell ends.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "jump",
-      "nome": "Jump",
-      "livello": 1,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "1 minuto",
-      "classi": [
-        "Druido",
-        "Ranger",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "You touch a creature. The creature's jump distance is tripled until the spell ends.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "knock",
-      "nome": "Knock",
-      "livello": 2,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "18 metri",
-      "componenti": [
-        "V"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Bardo",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "Choose an object that you can see within range. The object can be a door, a box, a chest, a set of manacles, a padlock, or another object that contains a mundane or magical means that prevents access. A target that is held shut by a mundane lock or that is stuck or barred becomes unlocked, unstuck, or unbarred. If the object has multiple locks, only one of them is unlocked. If you choose a target that is held shut with arcane lock, that spell is suppressed for 10 minutes, during which time the target can be opened and shut normally. When you cast the spell, a loud knock, audible from as far away as 300 feet, emanates from the target object.",
       "eTrucchetto": false,
       "scaling": null,
       "source": "System Reference Document"
@@ -6093,30 +5148,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "lesser_restoration",
-      "nome": "Lesser Restoration",
-      "livello": 2,
-      "scuola": "Abjurazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Druido",
-        "Paladino",
-        "Ranger"
-      ],
-      "descrizione": "You touch a creature and can end either one disease or one condition afflicting it. The condition can be blinded, deafened, paralyzed, or poisoned.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "levitate",
       "nome": "Levitate",
       "livello": 2,
@@ -6135,29 +5166,6 @@
       ],
       "descrizione": "One creature or object of your choice that you can see within range rises vertically, up to 20 feet, and remains suspended there for the duration. The spell can levitate a target that weighs up to 500 pounds. An unwilling creature that succeeds on a constitution saving throw is unaffected. The target can move only by pushing or pulling against a fixed object or surface within reach (such as a wall or a ceiling), which allows it to move as if it were climbing. You can change the target's altitude by up to 20 feet in either direction on your turn. If you are the target, you can move up or down as part of your move. Otherwise, you can use your action to move the target, which must remain within the spell's range. When the spell ends, the target floats gently to the ground if it is still aloft.",
       "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "light",
-      "nome": "Light",
-      "livello": 0,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "M"
-      ],
-      "durata": "1 ora",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "You touch one object that is no larger than 10 feet in any dimension. Until the spell ends, the object sheds bright light in a 20-foot radius and dim light for an additional 20 feet. The light can be colored as you like. Completely covering the object with something opaque blocks the light. The spell ends if you cast it again or dismiss it as an action. If you target an object held or worn by a hostile creature, that creature must succeed on a dexterity saving throw to avoid the spell.",
-      "eTrucchetto": true,
       "scaling": null,
       "source": "System Reference Document"
     },
@@ -6234,101 +5242,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "locate_object",
-      "nome": "Locate Object",
-      "livello": 2,
-      "scuola": "Divinazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 10 minuti",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Druido",
-        "Paladino",
-        "Ranger",
-        "Mago"
-      ],
-      "descrizione": "Describe or name an object that is familiar to you. You sense the direction to the object's location, as long as that object is within 1,000 feet of you. If the object is in motion, you know the direction of its movement. The spell can locate a specific object known to you, as long as you have seen it up close-within 30 feet-at least once. Alternatively, the spell can locate the nearest object of a particular kind, such as a certain kind of apparel, jewelry, furniture, tool, or weapon. This spell can't locate an object if any thickness of lead, even a thin sheet, blocks a direct path between you and the object.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "longstrider",
-      "nome": "Longstrider",
-      "livello": 1,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "1 ora",
-      "classi": [
-        "Bardo",
-        "Druido",
-        "Ranger",
-        "Mago"
-      ],
-      "descrizione": "You touch a creature. The target's speed increases by 10 feet until the spell ends.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 2nd level or higher, you can target one additional creature for each spell slot above 1st.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "mage_armor",
-      "nome": "Mage Armor",
-      "livello": 1,
-      "scuola": "Abjurazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "8 ore",
-      "classi": [
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "You touch a willing creature who isn't wearing armor, and a protective magical force surrounds it until the spell ends. The target's base AC becomes 13 + its Dexterity modifier. The spell ends if the target dons armor or if you dismiss the spell as an action.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "mage_hand",
-      "nome": "Mage Hand",
-      "livello": 0,
-      "scuola": "Invocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "9 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "1 minuto",
-      "classi": [
-        "Bardo",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "A spectral, floating hand appears at a point you choose within range. The hand lasts for the duration or until you dismiss it as an action. The hand vanishes if it is ever more than 30 feet away from you or if you cast this spell again. You can use your action to control the hand. You can use the hand to manipulate an object, open an unlocked door or container, stow or retrieve an item from an open container, or pour the contents out of a vial. You can move the hand up to 30 feet each time you use it. The hand can't attack, activate magic items, or carry more than 10 pounds.",
-      "eTrucchetto": true,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "magic_circle",
       "nome": "Magic Circle",
       "livello": 3,
@@ -6374,27 +5287,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "magic_missile",
-      "nome": "Magic Missile",
-      "livello": 1,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "36 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "You create three glowing darts of magical force. Each dart hits a creature of your choice that you can see within range. A dart deals 1d4 + 1 force damage to its target. The darts all strike simultaneously, and you can direct them to hit one creature or several.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 2nd level or higher, the spell creates one more dart for each slot level above 1st.",
-      "source": "System Reference Document"
-    },
-    {
       "id": "magic_mouth",
       "nome": "Magic Mouth",
       "livello": 2,
@@ -6414,28 +5306,6 @@
       "descrizione": "You implant a message within an object in range, a message that is uttered when a trigger condition is met. Choose an object that you can see and that isn't being worn or carried by another creature. Then speak the message, which must be 25 words or less, though it can be delivered over as long as 10 minutes. Finally, determine the circumstance that will trigger the spell to deliver your message. When that circumstance occurs, a magical mouth appears on the object and recites the message in your voice and at the same volume you spoke. If the object you chose has a mouth or something that looks like a mouth (for example, the mouth of a statue), the magical mouth appears there so that the words appear to come from the object's mouth. When you cast this spell, you can have the spell end after it delivers its message, or it can remain and repeat its message whenever the trigger occurs. The triggering circumstance can be as general or as detailed as you like, though it must be based on visual or audible conditions that occur within 30 feet of the object. For example, you could instruct the mouth to speak when any creature moves within 30 feet of the object or when a silver bell rings within 30 feet of it.",
       "eTrucchetto": false,
       "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "magic_weapon",
-      "nome": "Magic Weapon",
-      "livello": 2,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 azione bonus",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Fino a 1 ora",
-      "classi": [
-        "Chierico",
-        "Paladino",
-        "Mago"
-      ],
-      "descrizione": "You touch a nonmagical weapon. Until the spell ends, that weapon becomes a magic weapon with a +1 bonus to attack rolls and damage rolls.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 4th level or higher, the bonus increases to +2. When you use a spell slot of 6th level or higher, the bonus increases to +3.",
       "source": "System Reference Document"
     },
     {
@@ -6700,29 +5570,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "minor_illusion",
-      "nome": "Minor Illusion",
-      "livello": 0,
-      "scuola": "Illusione",
-      "tempo_lancio": "1 azione",
-      "raggio": "9 metri",
-      "componenti": [
-        "S",
-        "M"
-      ],
-      "durata": "1 minuto",
-      "classi": [
-        "Bardo",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "You create a sound or an image of an object within range that lasts for the duration. The illusion also ends if you dismiss it as an action or cast this spell again. If you create a sound, its volume can range from a whisper to a scream. It can be your voice, someone else's voice, a lion's roar, a beating of drums, or any other sound you choose. The sound continues unabated throughout the duration, or you can make discrete sounds at different times before the spell ends. If you create an image of an object-such as a chair, muddy footprints, or a small chest-it must be no larger than a 5-foot cube. The image can't create sound, light, smell, or any other sensory effect. Physical interaction with the image reveals it to be an illusion, because things can pass through it. If a creature uses its action to examine the sound or image, the creature can determine that it is an illusion with a successful Intelligence (Investigation) check against your spell save DC. If a creature discerns the illusion for what it is, the illusion becomes faint to the creature.",
-      "eTrucchetto": true,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "mirage_arcane",
       "nome": "Mirage Arcane",
       "livello": 7,
@@ -6745,30 +5592,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "mirror_image",
-      "nome": "Mirror Image",
-      "livello": 2,
-      "scuola": "Illusione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "1 minuto",
-      "classi": [
-        "Chierico",
-        "Druido",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "Three illusionary duplicates of yourself appear in your space. Until the end of the spell, duplicates move with you and imitate your actions, swapping their position so that it is impossible to determine which image is real. You can use your action to dispel the illusory duplicates. Whenever a creature is targeting you with an attack during the duration of the spell, roll 1d20 to determine if the attack does not target rather one of your duplicates. If you have three duplicates, you need 6 or more on your throw to lead the target of the attack to a duplicate. With two duplicates, you need 8 or more. With one duplicate, you need 11 or more. The CA of a duplicate is 10 + your Dexterity modifier. If an attack hits a duplicate, it is destroyed. A duplicate may be destroyed not just an attack on key. It ignores other damage and effects. The spell ends if the three duplicates are destroyed. A creature is unaffected by this fate if she can not see if it relies on a different meaning as vision, such as blind vision, or if it can perceive illusions as false, as with clear vision.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "mislead",
       "nome": "Mislead",
       "livello": 5,
@@ -6784,29 +5607,6 @@
         "Mago"
       ],
       "descrizione": "You become invisible at the same time that an illusory double of you appears where you are standing. The double lasts for the duration, but the invisibility ends if you attack or cast a spell. You can use your action to move your illusory double up to twice your speed and make it gesture, speak, and behave in whatever way you choose. You can see through its eyes and hear through its ears as if you were located where it is. On each of your turns as a bonus action, you can switch from using its senses to using your own, or back again. While you are using its senses, you are blinded and deafened in regard to your own surroundings.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "misty_step",
-      "nome": "Misty Step",
-      "livello": 2,
-      "scuola": "Invocazione",
-      "tempo_lancio": "1 azione bonus",
-      "raggio": "Personale",
-      "componenti": [
-        "V"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Druido",
-        "Paladino",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "Briefly surrounded by silvery mist, you teleport up to 30 feet to an unoccupied space that you can see.",
       "eTrucchetto": false,
       "scaling": null,
       "source": "System Reference Document"
@@ -6898,29 +5698,6 @@
         "Mago"
       ],
       "descrizione": "For the duration, you hide a target that you touch from divination magic. The target can be a willing creature or a place or an object no larger than 10 feet in any dimension. The target can't be targeted by any divination magic or perceived through magical scrying sensors.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "pass_without_trace",
-      "nome": "Pass without Trace",
-      "livello": 2,
-      "scuola": "Abjurazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 ora",
-      "classi": [
-        "Chierico",
-        "Druido",
-        "Ranger"
-      ],
-      "descrizione": "A veil of shadows and silence radiates from you, masking you and your companions from detection. For the duration, each creature you choose within 30 feet of you (including you) has a +10 bonus to Dexterity (Stealth) checks and can't be tracked except by magical means. A creature that receives this bonus leaves behind no tracks or other traces of its passage.",
       "eTrucchetto": false,
       "scaling": null,
       "source": "System Reference Document"
@@ -7081,29 +5858,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "poison_spray",
-      "nome": "Poison Spray",
-      "livello": 0,
-      "scuola": "Invocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "3 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Druido",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "You extend your hand toward a creature you can see within range and project a puff of noxious gas from your palm. The creature must succeed on a Constitution saving throw or take 1d12 poison damage.",
-      "eTrucchetto": true,
-      "scaling": "This spell's damage increases by 1d12 when you reach 5th level (2d12), 11th level (3d12), and 17th level (4d12).",
-      "source": "System Reference Document"
-    },
-    {
       "id": "polymorph",
       "nome": "Polymorph",
       "livello": 4,
@@ -7173,48 +5927,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "prayer_of_healing",
-      "nome": "Prayer of Healing",
-      "livello": 2,
-      "scuola": "Evocazione",
-      "tempo_lancio": "10 minuti",
-      "raggio": "9 metri",
-      "componenti": [
-        "V"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Chierico"
-      ],
-      "descrizione": "Up to six creatures of your choice that you can see within range each regain hit points equal to 2d8 + your spellcasting ability modifier. This spell has no effect on undead or constructs.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 3rd level or higher, the healing increases by 1d8 for each slot level above 2nd.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "prestidigitation",
-      "nome": "Prestidigitation",
-      "livello": 0,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "3 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "1 ora",
-      "classi": [
-        "Bardo",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "This spell is a minor magical trick that novice spellcasters use for practice. You create one of the following magical effects within 'range': \n- You create an instantaneous, harmless sensory effect, such as a shower of sparks, a puff of wind, faint musical notes, or an odd odor. \n- You instantaneously light or snuff out a candle, a torch, or a small campfire. \n- You instantaneously clean or soil an object no larger than 1 cubic foot. \n- You chill, warm, or flavor up to 1 cubic foot of nonliving material for 1 hour. \n- You make a color, a small mark, or a symbol appear on an object or a surface for 1 hour. \n- You create a nonmagical trinket or an illusory image that can fit in your hand and that lasts until the end of your next turn. \nIf you cast this spell multiple times, you can have up to three of its non-instantaneous effects active at a time, and you can dismiss such an effect as an action.",
-      "eTrucchetto": true,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "prismatic_spray",
       "nome": "Prismatic Spray",
       "livello": 7,
@@ -7274,26 +5986,6 @@
       "descrizione": "You make an area within range magically secure. The area is a cube that can be as small as 5 feet to as large as 100 feet on each side. The spell lasts for the duration or until you use an action to dismiss it. When you cast the spell, you decide what sort of security the spell provides, choosing any or all of the following properties: \n- Sound can't pass through the barrier at the edge of the warded area. \n- The barrier of the warded area appears dark and foggy, preventing vision (including darkvision) through it. \n- Sensors created by divination spells can't appear inside the protected area or pass through the barrier at its perimeter. \n- Creatures in the area can't be targeted by divination spells. \n- Nothing can teleport into or out of the warded area. \n- Planar travel is blocked within the warded area. \nCasting this spell on the same spot every day for a year makes this effect permanent.",
       "eTrucchetto": false,
       "scaling": "When you cast this spell using a spell slot of 5th level or higher, you can increase the size of the cube by 100 feet for each slot level beyond 4th. Thus you could protect a cube that can be up to 200 feet on one side by using a spell slot of 5th level.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "produce_flame",
-      "nome": "Produce Flame",
-      "livello": 0,
-      "scuola": "Invocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "10 minuti",
-      "classi": [
-        "Druido"
-      ],
-      "descrizione": "A flickering flame appears in your hand. The flame remains there for the duration and harms neither you nor your equipment. The flame sheds bright light in a 10-foot radius and dim light for an additional 10 feet. The spell ends if you dismiss it as an action or if you cast it again. You can also attack with the flame, although doing so ends the spell. When you cast this spell, or as an action on a later turn, you can hurl the flame at a creature within 30 feet of you. Make a ranged spell attack. On a hit, the target takes 1d8 fire damage.",
-      "eTrucchetto": true,
-      "scaling": "This spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
       "source": "System Reference Document"
     },
     {
@@ -7361,30 +6053,6 @@
         "Mago"
       ],
       "descrizione": "For the duration, the willing creature you touch has resistance to one damage type of your choice: acid, cold, fire, lightning, or thunder.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "protection_from_evil_and_good",
-      "nome": "Protection from Evil and Good",
-      "livello": 1,
-      "scuola": "Abjurazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 10 minuti",
-      "classi": [
-        "Chierico",
-        "Paladino",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "Until the spell ends, one willing creature you touch is protected against certain types of creatures: aberrations, celestials, elementals, fey, fiends, and undead. The protection grants several benefits. Creatures of those types have disadvantage on attack rolls against the target. The target also can't be charmed, frightened, or possessed by them. If the target is already charmed, frightened, or possessed by such a creature, the target has advantage on any new saving throw against the relevant effect.",
       "eTrucchetto": false,
       "scaling": null,
       "source": "System Reference Document"
@@ -7479,27 +6147,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "ray_of_frost",
-      "nome": "Ray of Frost",
-      "livello": 0,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "18 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "A frigid beam of blue-white light streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, it takes 1d8 cold damage, and its speed is reduced by 10 feet until the start of your next turn.",
-      "eTrucchetto": true,
-      "scaling": "The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
-      "source": "System Reference Document"
-    },
-    {
       "id": "regenerate",
       "nome": "Regenerate",
       "livello": 7,
@@ -7584,28 +6231,6 @@
       ],
       "descrizione": "A sphere of shimmering force encloses a creature or object of Large size or smaller within range. An unwilling creature must make a dexterity saving throw. On a failed save, the creature is enclosed for the duration. Nothing-not physical objects, energy, or other spell effects-can pass through the barrier, in or out, though a creature in the sphere can breathe there. The sphere is immune to all damage, and a creature or object inside can't be damaged by attacks or effects originating from outside, nor can a creature inside the sphere damage anything outside it. The sphere is weightless and just large enough to contain the creature or object inside. An enclosed creature can use its action to push against the sphere's walls and thus roll the sphere at up to half the creature's speed. Similarly, the globe can be picked up and moved by other creatures. A disintegrate spell targeting the globe destroys it without harming anything inside it.",
       "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "resistance",
-      "nome": "Resistance",
-      "livello": 0,
-      "scuola": "Abjurazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 minuto",
-      "classi": [
-        "Chierico",
-        "Druido"
-      ],
-      "descrizione": "You touch one willing creature. Once before the spell ends, the target can roll a d4 and add the number rolled to one saving throw of its choice. It can roll the die before or after making the saving throw. The spell then ends.",
-      "eTrucchetto": true,
       "scaling": null,
       "source": "System Reference Document"
     },
@@ -7698,71 +6323,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "sacred_flame",
-      "nome": "Sacred Flame",
-      "livello": 0,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "18 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Chierico"
-      ],
-      "descrizione": "Flame-like radiance descends on a creature that you can see within range. The target must succeed on a dexterity saving throw or take 1d8 radiant damage. The target gains no benefit from cover for this saving throw.",
-      "eTrucchetto": true,
-      "scaling": "The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "sanctuary",
-      "nome": "Sanctuary",
-      "livello": 1,
-      "scuola": "Abjurazione",
-      "tempo_lancio": "1 azione bonus",
-      "raggio": "9 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "1 minuto",
-      "classi": [
-        "Chierico",
-        "Paladino"
-      ],
-      "descrizione": "You ward a creature within range against attack. Until the spell ends, any creature who targets the warded creature with an attack or a harmful spell must first make a wisdom saving throw. On a failed save, the creature must choose a new target or lose the attack or spell. This spell doesn't protect the warded creature from area effects, such as the explosion of a fireball. If the warded creature makes an attack or casts a spell that affects an enemy creature, this spell ends.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "scorching_ray",
-      "nome": "Scorching Ray",
-      "livello": 2,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "36 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Chierico",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "You create three rays of fire and hurl them at targets within range. You can hurl them at one target or several. Make a ranged spell attack for each ray. On a hit, the target takes 2d6 fire damage.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 3rd level or higher, you create one additional ray for each slot level above 2nd.",
-      "source": "System Reference Document"
-    },
-    {
       "id": "scrying",
       "nome": "Scrying",
       "livello": 5,
@@ -7805,29 +6365,6 @@
         "Mago"
       ],
       "descrizione": "You hide a chest, and all its contents, on the Ethereal Plane. You must touch the chest and the miniature replica that serves as a material component for the spell. The chest can contain up to 12 cubic feet of nonliving material (3 feet by 2 feet by 2 feet). While the chest remains on the Ethereal Plane, you can use an action and touch the replica to recall the chest. It appears in an unoccupied space on the ground within 5 feet of you. You can send the chest back to the Ethereal Plane by using an action and touching both the chest and the replica. After 60 days, there is a cumulative 5 percent chance per day that the spell's effect ends. This effect ends if you cast this spell again, if the smaller replica chest is destroyed, or if you choose to end the spell as an action. If the spell ends and the larger chest is on the Ethereal Plane, it is irretrievably lost.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "see_invisibility",
-      "nome": "See Invisibility",
-      "livello": 2,
-      "scuola": "Divinazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "1 ora",
-      "classi": [
-        "Bardo",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "For the duration of the spell, you see invisible creatures and objects as if they were visible, and you can see through Ethereal. The ethereal objects and creatures appear ghostly translucent.",
       "eTrucchetto": false,
       "scaling": null,
       "source": "System Reference Document"
@@ -7923,141 +6460,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "shatter",
-      "nome": "Shatter",
-      "livello": 2,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "18 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "A sudden loud ringing noise, painfully intense, erupts from a point of your choice within range. Each creature in a 10-­--foot-­--radius sphere centered on that point must make a Constitution saving throw. A creature takes 3d8 thunder damage on a failed save, or half as much damage on a successful one. A creature made of inorganic material such as stone,crystal, or metal has disadvantage on this saving throw. A nonmagical object that isn't being worn or carried also takes the damage if it's in the spell's area.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for each slot level above 2nd.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "shield",
-      "nome": "Shield",
-      "livello": 1,
-      "scuola": "Abjurazione",
-      "tempo_lancio": "1 reazione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "1 round",
-      "classi": [
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "An invisible barrier of magical force appears and protects you. Until the start of your next turn, you have a +5 bonus to AC, including against the triggering attack, and you take no damage from magic missile.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "shield_of_faith",
-      "nome": "Shield of Faith",
-      "livello": 1,
-      "scuola": "Abjurazione",
-      "tempo_lancio": "1 azione bonus",
-      "raggio": "18 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 10 minuti",
-      "classi": [
-        "Chierico",
-        "Paladino"
-      ],
-      "descrizione": "A shimmering field appears and surrounds a creature of your choice within range, granting it a +2 bonus to AC for the duration.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "shocking_grasp",
-      "nome": "Shocking Grasp",
-      "livello": 0,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "Lightning springs from your hand to deliver a shock to a creature you try to touch. Make a melee spell attack against the target. You have advantage on the attack roll if the target is wearing armor made of metal. On a hit, the target takes 1d8 lightning damage, and it can't take reactions until the start of its next turn.",
-      "eTrucchetto": true,
-      "scaling": "The spell's damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8).",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "silence",
-      "nome": "Silence",
-      "livello": 2,
-      "scuola": "Illusione",
-      "tempo_lancio": "1 azione",
-      "raggio": "36 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Fino a 10 minuti",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Druido",
-        "Ranger"
-      ],
-      "descrizione": "For the duration, no sound can be created within or pass through a 20-foot-radius sphere centered on a point you choose within range. Any creature or object entirely inside the sphere is immune to thunder damage, and creatures are deafened while entirely inside it. Casting a spell that includes a verbal component is impossible there.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "silent_image",
-      "nome": "Silent Image",
-      "livello": 1,
-      "scuola": "Illusione",
-      "tempo_lancio": "1 azione",
-      "raggio": "18 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 10 minuti",
-      "classi": [
-        "Bardo",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "You create the image of an object, a creature, or some other visible phenomenon that is no larger than a 15-foot cube. The image appears at a spot within range and lasts for the duration. The image is purely visual; it isn't accompanied by sound, smell, or other sensory effects. You can use your action to cause the image to move to any spot within range. As the image changes location, you can alter its appearance so that its movements appear natural for the image. For example, if you create an image of a creature and move it, you can alter the image so that it appears to be walking. Physical interaction with the image reveals it to be an illusion, because things can pass through it. A creature that uses its action to examine the image can determine that it is an illusion with a successful Intelligence (Investigation) check against your spell save DC. If a creature discerns the illusion for what it is, the creature can see through the image.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "simulacrum",
       "nome": "Simulacrum",
       "livello": 7,
@@ -8076,30 +6478,6 @@
       "descrizione": "You shape an illusory duplicate of one beast or humanoid that is within range for the entire casting time of the spell. The duplicate is a creature, partially real and formed from ice or snow, and it can take actions and otherwise be affected as a normal creature. It appears to be the same as the original, but it has half the creature's hit point maximum and is formed without any equipment. Otherwise, the illusion uses all the statistics of the creature it duplicates. The simulacrum is friendly to you and creatures you designate. It obeys your spoken commands, moving and acting in accordance with your wishes and acting on your turn in combat. The simulacrum lacks the ability to learn or become more powerful, so it never increases its level or other abilities, nor can it regain expended spell slots. If the simulacrum is damaged, you can repair it in an alchemical laboratory, using rare herbs and minerals worth 100 gp per hit point it regains. The simulacrum lasts until it drops to 0 hit points, at which point it reverts to snow and melts instantly. If you cast this spell again, any currently active duplicates you created with this spell are instantly destroyed.",
       "eTrucchetto": false,
       "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "sleep",
-      "nome": "Sleep",
-      "livello": 1,
-      "scuola": "Ammaliamento",
-      "tempo_lancio": "1 azione",
-      "raggio": "27 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "1 minuto",
-      "classi": [
-        "Bardo",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "This spell sends creatures into a magical slumber. Roll 5d8; the total is how many hit points of creatures this spell can affect. Creatures within 20 feet of a point you choose within range are affected in ascending order of their current hit points (ignoring unconscious creatures). Starting with the creature that has the lowest current hit points, each creature affected by this spell falls unconscious until the spell ends, the sleeper takes damage, or someone uses an action to shake or slap the sleeper awake. Subtract each creature's hit points from the total before moving on to the creature with the next lowest hit points. A creature's hit points must be equal to or less than the remaining total for that creature to be affected. Undead and creatures immune to being charmed aren't affected by this spell.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 2nd level or higher, roll an additional 2d8 for each slot level above 1st.",
       "source": "System Reference Document"
     },
     {
@@ -8150,50 +6528,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "spare_the_dying",
-      "nome": "Spare the Dying",
-      "livello": 0,
-      "scuola": "Necromanzia",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Chierico"
-      ],
-      "descrizione": "You touch a living creature that has 0 hit points. The creature becomes stable. This spell has no effect on undead or constructs.",
-      "eTrucchetto": true,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "speak_with_animals",
-      "nome": "Speak with Animals",
-      "livello": 1,
-      "scuola": "Divinazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "10 minuti",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Druido",
-        "Paladino",
-        "Ranger"
-      ],
-      "descrizione": "You gain the ability to comprehend and verbally communicate with beasts for the duration. The knowledge and awareness of many beasts is limited by their intelligence, but at a minimum, beasts can give you information about nearby locations and monsters, including whatever they can perceive or have perceived within the past day. You might be able to persuade a beast to perform a small favor for you, at the DM's discretion.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
       "id": "speak_with_dead",
       "nome": "Speak with Dead",
       "livello": 3,
@@ -8233,30 +6567,6 @@
         "Ranger"
       ],
       "descrizione": "You imbue plants within 30 feet of you with limited sentience and animation, giving them the ability to communicate with you and follow your simple commands. You can question plants about events in the spell's area within the past day, gaining information about creatures that have passed, weather, and other circumstances. You can also turn difficult terrain caused by plant growth (such as thickets and undergrowth) into ordinary terrain that lasts for the duration. Or you can turn ordinary terrain where plants are present into difficult terrain that lasts for the duration, causing vines and branches to hinder pursuers, for example. Plants might be able to perform other tasks on your behalf, at the DM's discretion. The spell doesn't enable plants to uproot themselves and move about, but they can freely move branches, tendrils, and stalks. If a plant creature is in the area, you can communicate with it as if you shared a common language, but you gain no magical ability to influence it. This spell can cause the plants created by the entangle spell to release a restrained creature.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "spider_climb",
-      "nome": "Spider Climb",
-      "livello": 2,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Tocco",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 ora",
-      "classi": [
-        "Druido",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "Until the spell ends, one willing creature you touch gains the ability to move up, down, and across vertical surfaces and upside down along ceilings, while leaving its hands free. The target also gains a climbing speed equal to its walking speed.",
       "eTrucchetto": false,
       "scaling": null,
       "source": "System Reference Document"
@@ -8303,26 +6613,6 @@
       "descrizione": "You call forth spirits to protect you. They flit around you to a distance of 15 feet for the duration. If you are good or neutral, their spectral form appears angelic or fey (your choice). If you are evil, they appear fiendish. When you cast this spell, you can designate any number of creatures you can see to be unaffected by it. An affected creature's speed is halved in the area, and when the creature enters the area for the first time on a turn or starts its turn there, it must make a wisdom saving throw. On a failed save, the creature takes 3d8 radiant damage (if you are good or neutral) or 3d8 necrotic damage (if you are evil). On a successful save, the creature takes half as much damage.",
       "eTrucchetto": false,
       "scaling": "When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d8 for each slot level above 3rd.",
-      "source": "System Reference Document"
-    },
-    {
-      "id": "spiritual_weapon",
-      "nome": "Spiritual Weapon",
-      "livello": 2,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione bonus",
-      "raggio": "18 metri",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "1 minuto",
-      "classi": [
-        "Chierico"
-      ],
-      "descrizione": "You create a floating, spectral weapon within range that lasts for the duration or until you cast this spell again. When you cast the spell, you can make a melee spell attack against a creature within 5 feet of the weapon. On a hit, the target takes force damage equal to 1d8 + your spellcasting ability modifier. As a bonus action on your turn, you can move the weapon up to 20 feet and repeat the attack against a creature within 5 feet of it. The weapon can take whatever form you choose. Clerics of deities who are associated with a particular weapon (as St. Cuthbert is known for his mace and Thor for his hammer) make this spell's effect resemble that weapon.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1d8 for every two slot levels above the 2nd.",
       "source": "System Reference Document"
     },
     {
@@ -8415,30 +6705,6 @@
         "Druido"
       ],
       "descrizione": "A churning storm cloud forms, centered on a point you can see and spreading to a radius of 360 feet. Lightning flashes in the area, thunder booms, and strong winds roar. Each creature under the cloud (no more than 5,000 feet beneath the cloud) when it appears must make a constitution saving throw. On a failed save, a creature takes 2d6 thunder damage and becomes deafened for 5 minutes. Each round you maintain concentration on this spell, the storm produces additional effects on your turn.\n\n**Round 2.** Acidic rain falls from the cloud. Each creature and object under the cloud takes 1d6 acid damage.\n\n**Round 3.** You call six bolts of lightning from the cloud to strike six creatures or objects of your choice beneath the cloud. A given creature or object can't be struck by more than one bolt. A struck creature must make a dexterity saving throw. The creature takes 10d6 lightning damage on a failed save, or half as much damage on a successful one.\n\n**Round 4.** Hailstones rain down from the cloud. Each creature under the cloud takes 2d6 bludgeoning damage.\n\n**Round 5-10.** Gusts and freezing rain assail the area under the cloud. The area becomes difficult terrain and is heavily obscured. Each creature there takes 1d6 cold damage. Ranged weapon attacks in the area are impossible. The wind and rain count as a severe distraction for the purposes of maintaining concentration on spells. Finally, gusts of strong wind (ranging from 20 to 50 miles per hour) automatically disperse fog, mists, and similar phenomena in the area, whether mundane or magical.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "suggestion",
-      "nome": "Suggestion",
-      "livello": 2,
-      "scuola": "Ammaliamento",
-      "tempo_lancio": "1 azione",
-      "raggio": "9 metri",
-      "componenti": [
-        "V",
-        "M"
-      ],
-      "durata": "Fino a 8 ore",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Stregone",
-        "Warlock",
-        "Mago"
-      ],
-      "descrizione": "You suggest a course of activity (limited to a sentence or two) and magically influence a creature you can see within range that can hear and understand you. Creatures that can't be charmed are immune to this effect. The suggestion must be worded in such a manner as to make the course of action sound reasonable. Asking the creature to stab itself, throw itself onto a spear, immolate itself, or do some other obviously harmful act ends the spell. The target must make a wisdom saving throw. On a failed save, it pursues the course of action you described to the best of its ability. The suggested course of action can continue for the entire duration. If the suggested activity can be completed in a shorter time, the spell ends when the subject finishes what it was asked to do. You can also specify conditions that will trigger a special activity during the duration. For example, you might suggest that a knight give her warhorse to the first beggar she meets. If the condition isn't met before the spell expires, the activity isn't performed. If you or any of your companions damage the target, the spell ends.",
       "eTrucchetto": false,
       "scaling": null,
       "source": "System Reference Document"
@@ -8596,49 +6862,6 @@
       "descrizione": "As you cast the spell, you draw a 10-foot-diameter circle on the ground inscribed with sigils that link your location to a permanent teleportation circle of your choice whose sigil sequence you know and that is on the same plane of existence as you. A shimmering portal opens within the circle you drew and remains open until the end of your next turn. Any creature that enters the portal instantly appears within 5 feet of the destination circle or in the nearest unoccupied space if that space is occupied. Many major temples, guilds, and other important places have permanent teleportation circles inscribed somewhere within their confines. Each such circle includes a unique sigil sequence-a string of magical runes arranged in a particular pattern. When you first gain the ability to cast this spell, you learn the sigil sequences for two destinations on the Material Plane, determined by the DM. You can learn additional sigil sequences during your adventures. You can commit a new sigil sequence to memory after studying it for 1 minute. You can create a permanent teleportation circle by casting this spell in the same location every day for one year. You need not use the circle to teleport when you cast the spell in this way.",
       "eTrucchetto": false,
       "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "thaumaturgy",
-      "nome": "Thaumaturgy",
-      "livello": 0,
-      "scuola": "Trasmutazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "9 metri",
-      "componenti": [
-        "V"
-      ],
-      "durata": "1 minuto",
-      "classi": [
-        "Chierico"
-      ],
-      "descrizione": "You manifest a minor wonder, a sign of supernatural power, within range. You create one of the following magical effects within range. \n- Your voice booms up to three times as loud as normal for 1 minute. \n- You cause flames to flicker, brighten, dim, or change color for 1 minute. \n- You cause harmless tremors in the ground for 1 minute. \n- You create an instantaneous sound that originates from a point of your choice within range, such as a rumble of thunder, the cry of a raven, or ominous whispers. \n- You instantaneously cause an unlocked door or window to fly open or slam shut. \n- You alter the appearance of your eyes for 1 minute. \nIf you cast this spell multiple times, you can have up to three of its 1-minute effects active at a time, and you can dismiss such an effect as an action.",
-      "eTrucchetto": true,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "thunderwave",
-      "nome": "Thunderwave",
-      "livello": 1,
-      "scuola": "Evocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "Personale",
-      "componenti": [
-        "V",
-        "S"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Bardo",
-        "Chierico",
-        "Druido",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "A wave of thunderous force sweeps out from you. Each creature in a 15-foot cube originating from you must make a constitution saving throw. On a failed save, a creature takes 2d8 thunder damage and is pushed 10 feet away from you. On a successful save, the creature takes half as much damage and isn't pushed. In addition, unsecured objects that are completely within the area of effect are automatically pushed 10 feet away from you by the spell's effect, and the spell emits a thunderous boom audible out to 300 feet.",
-      "eTrucchetto": false,
-      "scaling": "When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d8 for each slot level above 1st.",
       "source": "System Reference Document"
     },
     {
@@ -8887,25 +7110,6 @@
       "source": "System Reference Document"
     },
     {
-      "id": "vicious_mockery",
-      "nome": "Vicious Mockery",
-      "livello": 0,
-      "scuola": "Ammaliamento",
-      "tempo_lancio": "1 azione",
-      "raggio": "18 metri",
-      "componenti": [
-        "V"
-      ],
-      "durata": "Istantaneo",
-      "classi": [
-        "Bardo"
-      ],
-      "descrizione": "You unleash a string of insults laced with subtle enchantments at a creature you can see within range. If the target can hear you (though it need not understand you), it must succeed on a Wisdom saving throw or take 1d4 psychic damage and have disadvantage on the next attack roll it makes before the end of its next turn.",
-      "eTrucchetto": true,
-      "scaling": "This spell's damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4).",
-      "source": "System Reference Document"
-    },
-    {
       "id": "wall_of_fire",
       "nome": "Wall of Fire",
       "livello": 4,
@@ -9081,29 +7285,6 @@
         "Stregone"
       ],
       "descrizione": "This spell grants the ability to move across any liquid surface-such as water, acid, mud, snow, quicksand, or lava-as if it were harmless solid ground (creatures crossing molten lava can still take damage from the heat). Up to ten willing creatures you can see within range gain this ability for the duration. If you target a creature submerged in a liquid, the spell carries the target to the surface of the liquid at a rate of 60 feet per round.",
-      "eTrucchetto": false,
-      "scaling": null,
-      "source": "System Reference Document"
-    },
-    {
-      "id": "web",
-      "nome": "Web",
-      "livello": 2,
-      "scuola": "Invocazione",
-      "tempo_lancio": "1 azione",
-      "raggio": "18 metri",
-      "componenti": [
-        "V",
-        "S",
-        "M"
-      ],
-      "durata": "Fino a 1 ora",
-      "classi": [
-        "Druido",
-        "Stregone",
-        "Mago"
-      ],
-      "descrizione": "You conjure a mass of thick, sticky webbing at a point of your choice within range. The webs fill a 20-foot cube from that point for the duration. The webs are difficult terrain and lightly obscure their area. If the webs aren't anchored between two solid masses (such as walls or trees) or layered across a floor, wall, or ceiling, the conjured web collapses on itself, and the spell ends at the start of your next turn. Webs layered over a flat surface have a depth of 5 feet. Each creature that starts its turn in the webs or that enters them during its turn must make a dexterity saving throw. On a failed save, the creature is restrained as long as it remains in the webs or until it breaks free. A creature restrained by the webs can use its action to make a Strength check against your spell save DC. If it succeeds, it is no longer restrained. The webs are flammable. Any 5-foot cube of webs exposed to fire burns away in 1 round, dealing 2d4 fire damage to any creature that starts its turn in the fire.",
       "eTrucchetto": false,
       "scaling": null,
       "source": "System Reference Document"


### PR DESCRIPTION
## Summary
- `assets/data/spells.json` aveva 81 `id` duplicati: una voce già tradotta in italiano (originaria) e una seconda voce inglese con lo stesso id, aggiunta dall'import massivo dall'SRD (commit `faf1aea`) senza deduplicare contro le voci esistenti
- Rimossa la voce inglese duplicata per ciascuno degli 81 id, mantenendo sempre la voce italiana originale (verificato: è sempre la prima nel file, quindi il dedup "mantieni la prima occorrenza per id" preserva esattamente le traduzioni esistenti)
- `total_spells` aggiornato da 407 a 326 incantesimi univoci
- Nessuna perdita di contenuto: era lo stesso incantesimo già presente e tradotto, solo con una copia inglese di troppo

Chiude #42

## Test plan
- [x] Verificato via script che i duplicati residui sono 0 e che le voci italiane (Spruzzo Acido, Dardo Infuocato, Trucchi Druidici, ecc.) sono ancora presenti
- [x] `flutter analyze` pulito
- [x] `flutter test` verde