### PR TITLE
Deriva classiConsigliate per il catalogo importato e filtra il randomico

### DIFF
--- a/lib/data/db_equip.dart
+++ b/lib/data/db_equip.dart
@@ -1,5 +1,68 @@
 // lib/data/db_equip.dart
 
+import 'db_classi.dart';
+
+/// Alcune classi hanno competenze su armi specifiche (non l'intera
+/// categoria "semplici"/"da guerra"), elencate in db_classi.dart con il
+/// nome italiano dell'arma al plurale (es. "Spade corte"). Mappa quei nomi
+/// al nome inglese stabile dell'arma corrispondente in equipment.json, per
+/// poter derivare le classi consigliate anche per il catalogo importato.
+const Map<String, String> _aliasCompetenzaArma = {
+  'Balestre leggere': 'Crossbow, light',
+  'Balestre a mano': 'Crossbow, hand',
+  'Spade corte': 'Shortsword',
+  'Spade lunghe': 'Longsword',
+  'Stocchi': 'Rapier',
+  'Bastoni': 'Quarterstaff',
+  'Bastoni ferrati': 'Quarterstaff',
+  'Fionde': 'Sling',
+  'Lance': 'Spear',
+  'Pugnali': 'Dagger',
+  'Falci': 'Sickle',
+  'Mazze': 'Mace',
+  'Dardi': 'Dart',
+};
+
+bool _classeCompetenteArma(Classe classe, String categoria, String nomeArma) {
+  final generica =
+      categoria.startsWith('simple') ? 'Armi semplici' : 'Armi da guerra';
+  if (classe.competenzeArmi.contains(generica)) return true;
+  return classe.competenzeArmi.any((c) => _aliasCompetenzaArma[c] == nomeArma);
+}
+
+/// Classi consigliate per un'arma importata da equipment.json, derivate
+/// dalle competenze d'arma di ciascuna classe in db_classi.dart.
+List<String> classiConsigliatePerArma(String categoria, String nomeArma) =>
+    classiList
+        .where((c) => _classeCompetenteArma(c, categoria, nomeArma))
+        .map((c) => c.nome)
+        .toList();
+
+bool _classeCompetenteArmatura(Classe classe, String categoria) {
+  switch (categoria) {
+    case 'light':
+      return classe.competenzeArmature.any((c) => c.startsWith('Leggere')) ||
+          classe.competenzeArmature.contains('Tutte le armature');
+    case 'medium':
+      return classe.competenzeArmature.any((c) => c.startsWith('Medie')) ||
+          classe.competenzeArmature.contains('Tutte le armature');
+    case 'heavy':
+      return classe.competenzeArmature.contains('Tutte le armature');
+    case 'shields':
+      return classe.competenzeArmature.any((c) => c.startsWith('Scudi'));
+    default:
+      return false;
+  }
+}
+
+/// Classi consigliate per un'armatura importata da equipment.json, derivate
+/// dalle competenze d'armatura di ciascuna classe in db_classi.dart.
+List<String> classiConsigliatePerArmatura(String categoria) =>
+    classiList
+        .where((c) => _classeCompetenteArmatura(c, categoria))
+        .map((c) => c.nome)
+        .toList();
+
 class OggettoEquip {
   final String nome;
   final String tipo; // "arma", "armatura", "oggetto"
@@ -37,6 +100,10 @@ class OggettoEquip {
       danno: json['damage'],
       costoMO: _parseCost(json['cost']),
       pesoKg: _parseWeight(json['weight']),
+      classiConsigliate: classiConsigliatePerArma(
+        weaponType,
+        json['name'] ?? '',
+      ),
     );
   }
 
@@ -53,6 +120,7 @@ class OggettoEquip {
       danno: null,
       costoMO: _parseCost(json['cost']),
       pesoKg: _parseWeight(json['weight']),
+      classiConsigliate: classiConsigliatePerArmatura(armorType),
     );
   }
 

--- a/lib/pg_base/steps/step_equip.dart
+++ b/lib/pg_base/steps/step_equip.dart
@@ -96,10 +96,28 @@ class _StepEquipScreenState extends State<StepEquipScreen> {
   T? _casuale<T>(List<T> lista) =>
       lista.isEmpty ? null : lista[Random().nextInt(lista.length)];
 
+  /// Come [_casuale], ma pesca solo tra gli oggetti consigliati per
+  /// [classe] quando ce ne sono (un oggetto senza classi consigliate resta
+  /// disponibile per tutti). Se nessun oggetto e' consigliato per la
+  /// classe scelta, ripiega sull'intera lista per non lasciare lo slot
+  /// vuoto.
+  OggettoEquip? _casualeCompatibile(List<OggettoEquip> lista, String classe) {
+    final compatibili =
+        lista
+            .where(
+              (o) =>
+                  o.classiConsigliate.isEmpty ||
+                  o.classiConsigliate.contains(classe),
+            )
+            .toList();
+    return _casuale(compatibili.isNotEmpty ? compatibili : lista);
+  }
+
   void _randomizza() {
+    final classePG = widget.factory.build().classe;
     setState(() {
-      armaSelezionata = _casuale(armi);
-      armaturaSelezionata = _casuale(armature);
+      armaSelezionata = _casualeCompatibile(armi, classePG);
+      armaturaSelezionata = _casualeCompatibile(armature, classePG);
       kitSelezionato = _casuale(kit);
       strumentoSelezionato = _casuale(strumenti);
     });

--- a/test/db_equip_test.dart
+++ b/test/db_equip_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dnd_master_aid/data/db_equip.dart';
+
+void main() {
+  group('classiConsigliatePerArma', () {
+    test('arma semplice generica e consigliata a chi ha "Armi semplici"', () {
+      final classi = classiConsigliatePerArma('simple_melee', 'Club');
+      expect(classi, contains('Guerriero'));
+      expect(classi, contains('Chierico'));
+      expect(classi, isNot(contains('Mago')));
+    });
+
+    test('arma da guerra generica esclude chi non ha "Armi da guerra"', () {
+      final classi = classiConsigliatePerArma('martial_melee', 'Battleaxe');
+      expect(classi, contains('Guerriero'));
+      expect(classi, contains('Barbaro'));
+      expect(classi, isNot(contains('Chierico')));
+      expect(classi, isNot(contains('Mago')));
+    });
+
+    test('eccezioni nominali per classi senza competenza generica', () {
+      final quarterstaff = classiConsigliatePerArma(
+        'simple_melee',
+        'Quarterstaff',
+      );
+      expect(quarterstaff, contains('Mago'));
+      expect(quarterstaff, contains('Druido'));
+
+      final rapier = classiConsigliatePerArma('martial_melee', 'Rapier');
+      expect(rapier, contains('Bardo'));
+      expect(rapier, contains('Ladro'));
+      expect(rapier, isNot(contains('Mago')));
+    });
+  });
+
+  group('classiConsigliatePerArmatura', () {
+    test('armatura leggera disponibile anche a chi ha solo "Leggere"', () {
+      final classi = classiConsigliatePerArmatura('light');
+      expect(classi, contains('Bardo'));
+      expect(classi, contains('Guerriero'));
+      expect(classi, isNot(contains('Mago')));
+    });
+
+    test('armatura pesante solo per chi ha "Tutte le armature"', () {
+      final classi = classiConsigliatePerArmatura('heavy');
+      expect(classi, contains('Guerriero'));
+      expect(classi, contains('Paladino'));
+      expect(classi, isNot(contains('Barbaro')));
+      expect(classi, isNot(contains('Chierico')));
+    });
+
+    test('scudi', () {
+      final classi = classiConsigliatePerArmatura('shields');
+      expect(classi, contains('Guerriero'));
+      expect(classi, contains('Chierico'));
+      expect(classi, isNot(contains('Mago')));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Nuove funzioni `classiConsigliatePerArma`/`classiConsigliatePerArmatura` in `lib/data/db_equip.dart`, che derivano le classi compatibili con un'arma/armatura dalle competenze d'arma/armatura già presenti per ciascuna classe in `db_classi.dart` (competenza generica "Armi semplici"/"Armi da guerra"/"Leggere"/"Medie"/"Tutte le armature"/"Scudi", più le eccezioni nominali come "Spade corte" per Bardo/Ladro o "Bastoni ferrati" per Mago/Druido)
- `OggettoEquip.fromWeaponJson`/`fromArmorJson` ora valorizzano `classiConsigliate` per tutte le ~49 armi/armature importate da `equipment.json`, prima sempre vuoto
- "Equipaggiamento casuale" (`step_equip.dart`) ora pesca solo tra gli oggetti consigliati per la classe del personaggio quando ce ne sono, con fallback sull'intera lista se nessun oggetto risultasse compatibile (mai lasciare lo slot vuoto)
- Le ~20 voci storiche scritte a mano non sono toccate: avevano già `classiConsigliate` curato manualmente

Chiude #26

## Test plan
- [x] Nuovo `test/db_equip_test.dart`: verifica competenza generica (Guerriero/Chierico su armi semplici, esclusione Mago), eccezioni nominali (Mago/Druido su Bastone Ferrato, Bardo/Ladro su Stocco), e armature (leggera/pesante/scudi) — tutti verdi
- [x] `flutter analyze` pulito
- [x] `flutter test` verde (7/7)
- [x] `flutter build web` completato senza errori