### PR TITLE
Rende visibile dalla Home la scheda viva del personaggio

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -82,7 +82,7 @@ class HomePage extends StatelessWidget {
       'id': 'salvati',
       'nome': 'I Miei Personaggi',
       'icona': '📖',
-      'descr': 'Personaggi salvati',
+      'descr': 'Scheda viva: PF, denaro, condizioni',
       'attivo': true,
     },
     {


### PR DESCRIPTION
## Summary
- La card "I Miei Personaggi" in Home aveva la descrizione generica "Personaggi salvati", che non lasciava intuire l'esistenza delle funzionalità di scheda viva aggiunte con le PR #21-#24 e #37 (PF, denaro, inventario, condizioni, incantesimi, CA/CD, azioni leggendarie)
- Aggiornata la descrizione in "Scheda viva: PF, denaro, condizioni" per renderle immediatamente visibili a chi apre l'app

Chiude #25

## Test plan
- [x] Screenshot verificati in layout mobile (< 600px) e griglia tablet (>= 600px): il testo più lungo non causa overflow in nessuno dei due
- [x] `flutter analyze` pulito
- [x] `flutter test` verde