### PR TITLE
Aggiunge import/export della scheda personaggio (condivisione via WhatsApp)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:taskAffinity=""
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
@@ -49,6 +49,17 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <!-- Apre l'app quando si tocca un file .dnd ricevuto da
+                 un'altra app (es. un personaggio condiviso via WhatsApp).
+                 Vincolato a .dnd tramite pathPattern per non comparire
+                 come opzione "Apri con" su file qualsiasi. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="content" android:mimeType="*/*" android:pathPattern=".*\\.dnd"/>
+                <data android:scheme="file" android:mimeType="*/*" android:pathPattern=".*\\.dnd"/>
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/lib/factory_pg_base.dart
+++ b/lib/factory_pg_base.dart
@@ -56,6 +56,7 @@ class PGBase {
   final List<String> modificatoriAttivi;
   final Map<String, int> slotIncantesimoUsati;
   final List<String> talenti;
+  final String proprietario;
 
   PGBase({
     String? id,
@@ -92,6 +93,7 @@ class PGBase {
     this.modificatoriAttivi = const [],
     this.slotIncantesimoUsati = const {},
     this.talenti = const [],
+    this.proprietario = '',
   }) : id = id ?? const Uuid().v4(),
        dataSalvataggio = dataSalvataggio ?? DateTime.now(),
        puntiVitaCorrenti = puntiVitaCorrenti ?? puntiVita;
@@ -130,6 +132,7 @@ class PGBase {
     List<String>? modificatoriAttivi,
     Map<String, int>? slotIncantesimoUsati,
     List<String>? talenti,
+    String? proprietario,
   }) {
     return PGBase(
       id: id,
@@ -167,6 +170,7 @@ class PGBase {
       modificatoriAttivi: modificatoriAttivi ?? this.modificatoriAttivi,
       slotIncantesimoUsati: slotIncantesimoUsati ?? this.slotIncantesimoUsati,
       talenti: talenti ?? this.talenti,
+      proprietario: proprietario ?? this.proprietario,
     );
   }
 
@@ -205,6 +209,7 @@ class PGBase {
     'modificatoriAttivi': modificatoriAttivi,
     'slotIncantesimoUsati': slotIncantesimoUsati,
     'talenti': talenti,
+    'proprietario': proprietario,
   };
 
   factory PGBase.fromJson(Map<String, dynamic> json) => PGBase(
@@ -265,6 +270,7 @@ class PGBase {
           {},
     ),
     talenti: List<String>.from(json['talenti'] ?? []),
+    proprietario: json['proprietario'] as String? ?? '',
   );
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,14 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:provider/provider.dart';
+import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 
 // === IMPORTAZIONI ===
 import 'core/app_theme.dart';
+import 'core/logger.dart';
 import 'pg_base/main_pg_base.dart'; // PG Base Wizard
 import 'screens/coming_soon.dart'; // Schermata per funzionalità disattivate
 import 'screens/dice_roller.dart'; // Modulo dadi
@@ -13,6 +18,7 @@ import 'screens/combat_tracker_screen.dart'; // Tracker iniziativa/combattimento
 import 'package:dnd_master_aid/factory_pg_base.dart';
 import 'providers/character_provider.dart';
 import 'providers/saved_characters_provider.dart';
+import 'utils/character_share.dart';
 import 'widgets/banner_ad_widget.dart';
 import 'widgets/mobile/mobile_scaffold.dart';
 import 'widgets/mobile/mobile_card.dart';
@@ -26,8 +32,82 @@ void main() {
   runApp(const DnDMasterAidApp());
 }
 
-class DnDMasterAidApp extends StatelessWidget {
+class DnDMasterAidApp extends StatefulWidget {
   const DnDMasterAidApp({super.key});
+
+  @override
+  State<DnDMasterAidApp> createState() => _DnDMasterAidAppState();
+}
+
+class _DnDMasterAidAppState extends State<DnDMasterAidApp> {
+  final _navigatorKey = GlobalKey<NavigatorState>();
+  StreamSubscription<List<SharedMediaFile>>? _intentSub;
+
+  @override
+  void initState() {
+    super.initState();
+    _avviaAscoltoCondivisione();
+  }
+
+  /// Ascolta i file .dnd ricevuti da altre app (es. aperti da WhatsApp) e
+  /// li importa automaticamente tra "I Miei Personaggi". Il plugin non e'
+  /// implementato su web/desktop: qualunque errore viene ignorato in modo
+  /// da non bloccare l'avvio dell'app su quelle piattaforme.
+  void _avviaAscoltoCondivisione() {
+    if (kIsWeb) return;
+    try {
+      _intentSub = ReceiveSharingIntent.instance.getMediaStream().listen(
+        _gestisciFileCondivisi,
+        onError: (e) => AppLogger.error('Errore stream file condivisi', e),
+      );
+      ReceiveSharingIntent.instance.getInitialMedia().then((value) {
+        _gestisciFileCondivisi(value);
+        ReceiveSharingIntent.instance.reset();
+      });
+    } catch (e) {
+      AppLogger.error('Ricezione file condivisi non disponibile', e);
+    }
+  }
+
+  Future<void> _gestisciFileCondivisi(List<SharedMediaFile> files) async {
+    if (files.isEmpty) return;
+    final file = files.firstWhere(
+      (f) => f.path.endsWith(estensioneFileEsportazione),
+      orElse: () => files.first,
+    );
+
+    final context = _navigatorKey.currentState?.context;
+    if (context == null || !context.mounted) return;
+
+    try {
+      final pg = await importaPersonaggioDaFile(file.path);
+      if (!context.mounted) return;
+      await context.read<SavedCharactersProvider>().save(pg);
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            '${pg.nome.isNotEmpty ? pg.nome : "Personaggio"} importato',
+          ),
+        ),
+      );
+    } catch (e) {
+      AppLogger.error('Import da file condiviso fallito', e);
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Il file ricevuto non è una scheda personaggio valida'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _intentSub?.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -37,6 +117,7 @@ class DnDMasterAidApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => SavedCharactersProvider()),
       ],
       child: MaterialApp(
+        navigatorKey: _navigatorKey,
         title: 'D&D Master Aid',
         debugShowCheckedModeBanner: false,
         theme: buildAppTheme(),

--- a/lib/screens/saved_characters_screen.dart
+++ b/lib/screens/saved_characters_screen.dart
@@ -1,7 +1,9 @@
 import 'dart:math';
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:share_plus/share_plus.dart';
 import '../data/db_condizioni.dart';
 import '../data/db_slot_incantesimi.dart';
 import '../data/db_talenti.dart';
@@ -9,6 +11,7 @@ import '../factory_pg_base.dart';
 import '../pg_base/utils/asi_helper.dart';
 import '../pg_base/utils/pf_helper.dart';
 import '../providers/saved_characters_provider.dart';
+import '../utils/character_share.dart';
 import '../widgets/mobile/mobile_scaffold.dart';
 import 'spell_cards_screen.dart';
 
@@ -32,6 +35,13 @@ class _SavedCharactersScreenState extends State<SavedCharactersScreen> {
   Widget build(BuildContext context) {
     return MobileScaffold(
       title: 'I Miei Personaggi',
+      actions: [
+        IconButton(
+          onPressed: () => _mostraImportaScheda(context),
+          icon: const Icon(Icons.file_download_outlined),
+          tooltip: 'Importa scheda',
+        ),
+      ],
       body: Consumer<SavedCharactersProvider>(
         builder: (context, provider, _) {
           if (provider.isLoading) {
@@ -93,6 +103,17 @@ class _SavedCharactersScreenState extends State<SavedCharactersScreen> {
     );
   }
 
+  void _mostraImportaScheda(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => const _ImportaSchedaSheet(),
+    );
+  }
+
   void _apriScheda(BuildContext context, PGBase pg) {
     showModalBottomSheet(
       context: context,
@@ -146,6 +167,94 @@ class _SavedCharactersScreenState extends State<SavedCharactersScreen> {
               ),
             ],
           ),
+    );
+  }
+}
+
+/// Incolla il codice ricevuto (es. da WhatsApp) e importa il personaggio
+/// tra "I Miei Personaggi". Vedi lib/utils/character_share.dart per il
+/// formato del codice.
+class _ImportaSchedaSheet extends StatefulWidget {
+  const _ImportaSchedaSheet();
+
+  @override
+  State<_ImportaSchedaSheet> createState() => _ImportaSchedaSheetState();
+}
+
+class _ImportaSchedaSheetState extends State<_ImportaSchedaSheet> {
+  final _controller = TextEditingController();
+  String? _errore;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _importa() async {
+    setState(() => _errore = null);
+    try {
+      final pg = importaPersonaggio(_controller.text);
+      await context.read<SavedCharactersProvider>().save(pg);
+      if (!mounted) return;
+      Navigator.pop(context);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            '${pg.nome.isNotEmpty ? pg.nome : "Personaggio"} importato',
+          ),
+        ),
+      );
+    } on FormatException catch (e) {
+      setState(() => _errore = e.message);
+    } catch (_) {
+      setState(() => _errore = 'Codice non valido.');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 20,
+        right: 20,
+        top: 20,
+        bottom: MediaQuery.of(context).viewInsets.bottom + 20,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Importa scheda',
+            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Incolla qui il codice ricevuto dal giocatore (es. via WhatsApp).',
+            style: TextStyle(fontSize: 13, color: Colors.grey[600]),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _controller,
+            maxLines: 4,
+            decoration: InputDecoration(
+              hintText: 'DNDMA1:...',
+              border: const OutlineInputBorder(),
+              errorText: _errore,
+            ),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton.icon(
+              onPressed: _importa,
+              icon: const Icon(Icons.check),
+              label: const Text('Importa'),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -300,12 +409,23 @@ class _SchedaBottomSheetState extends State<_SchedaBottomSheet> {
                   ),
                 ),
                 const SizedBox(height: 16),
-                Text(
-                  pg.nome.isNotEmpty ? pg.nome : 'Personaggio',
-                  style: const TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                  ),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        pg.nome.isNotEmpty ? pg.nome : 'Personaggio',
+                        style: const TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      onPressed: _condividi,
+                      icon: const Icon(Icons.share),
+                      tooltip: 'Condividi personaggio',
+                    ),
+                  ],
                 ),
                 const SizedBox(height: 4),
                 Row(
@@ -324,6 +444,8 @@ class _SchedaBottomSheetState extends State<_SchedaBottomSheet> {
                       ),
                   ],
                 ),
+                const SizedBox(height: 8),
+                _ProprietarioSection(pg: pg),
                 const Divider(height: 24),
                 _PfSection(pg: pg),
                 const SizedBox(height: 8),
@@ -412,6 +534,29 @@ class _SchedaBottomSheetState extends State<_SchedaBottomSheet> {
               ],
             ),
           ),
+    );
+  }
+
+  /// Condivide il personaggio tramite il pannello di condivisione nativo
+  /// del sistema operativo (WhatsApp, email, ecc.). Su web condivide solo
+  /// il codice testuale (niente concetto di file "apri con" nel browser);
+  /// su piattaforme native condivide un file .dnd, cosi' che un tap su di
+  /// esso, una volta ricevuto, apra direttamente l'app (vedi il filtro in
+  /// AndroidManifest.xml).
+  Future<void> _condividi() async {
+    final nome = _pg.nome.isNotEmpty ? _pg.nome : 'Senza nome';
+    if (kIsWeb) {
+      await SharePlus.instance.share(
+        ShareParams(
+          text: esportaPersonaggio(_pg),
+          subject: 'Personaggio D&D: $nome',
+        ),
+      );
+      return;
+    }
+    final file = await creaFileEsportazione(_pg);
+    await SharePlus.instance.share(
+      ShareParams(files: [XFile(file.path)], text: 'Personaggio D&D: $nome'),
     );
   }
 
@@ -709,6 +854,76 @@ class _SchedaBottomSheetState extends State<_SchedaBottomSheet> {
               ),
             );
           }).toList(),
+    );
+  }
+}
+
+/// Campo libero per annotare a chi appartiene il personaggio: utile per il
+/// Master quando importa le schede di piu' giocatori e deve distinguerle
+/// a colpo d'occhio.
+class _ProprietarioSection extends StatefulWidget {
+  final PGBase pg;
+
+  const _ProprietarioSection({required this.pg});
+
+  @override
+  State<_ProprietarioSection> createState() => _ProprietarioSectionState();
+}
+
+class _ProprietarioSectionState extends State<_ProprietarioSection> {
+  late PGBase _pg;
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _pg = widget.pg;
+    _controller = TextEditingController(text: _pg.proprietario);
+  }
+
+  @override
+  void didUpdateWidget(covariant _ProprietarioSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.pg, widget.pg)) {
+      _pg = widget.pg;
+      _controller.text = _pg.proprietario;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _salva() {
+    final valore = _controller.text.trim();
+    if (valore == _pg.proprietario) return;
+    _pg = _pg.copyWith(proprietario: valore);
+    context.read<SavedCharactersProvider>().save(_pg);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: TextField(
+            controller: _controller,
+            decoration: const InputDecoration(
+              labelText: 'Di chi è questo personaggio',
+              hintText: 'Es. Marco',
+              isDense: true,
+            ),
+            onSubmitted: (_) => _salva(),
+          ),
+        ),
+        IconButton(
+          onPressed: _salva,
+          icon: const Icon(Icons.check, size: 20),
+          tooltip: 'Salva',
+        ),
+      ],
     );
   }
 }

--- a/lib/utils/character_share.dart
+++ b/lib/utils/character_share.dart
@@ -1,0 +1,78 @@
+// lib/utils/character_share.dart
+//
+// Serializza/deserializza un PGBase in un codice testuale condivisibile
+// (es. tramite WhatsApp), cosi' un giocatore puo' mandare il proprio
+// personaggio al Master perche' lo carichi tra "I Miei Personaggi".
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+import '../factory_pg_base.dart';
+
+/// Prefisso che identifica un codice personaggio valido e ne marca la
+/// versione del formato, per poter evolvere il formato in futuro senza
+/// rompere l'import di codici generati da versioni precedenti dell'app.
+const String _prefissoCodice = 'DNDMA1:';
+
+/// Estensione del file esportato: registrata in AndroidManifest.xml cosi'
+/// che, ricevuto ad es. da WhatsApp, un tap sul file apra direttamente
+/// questa app invece di un visualizzatore generico.
+const String estensioneFileEsportazione = '.dnd';
+
+/// Codifica [pg] in un codice testuale da condividere (es. via il pannello
+/// di condivisione nativo). Il codice e' un blob base64 per restare
+/// leggibile/incollabile in qualunque app di messaggistica, senza andare
+/// in conflitto con virgolette o a-capo del JSON sottostante.
+String esportaPersonaggio(PGBase pg) {
+  final jsonString = jsonEncode(pg.toJson());
+  return _prefissoCodice + base64Encode(utf8.encode(jsonString));
+}
+
+/// Decodifica un codice prodotto da [esportaPersonaggio] e ricostruisce il
+/// [PGBase]. Lancia [FormatException] se il codice non e' valido.
+PGBase importaPersonaggio(String codice) {
+  final pulito = codice.trim();
+  if (!pulito.startsWith(_prefissoCodice)) {
+    throw const FormatException(
+      'Codice non riconosciuto: assicurati di aver incollato l\'intero '
+      'codice ricevuto.',
+    );
+  }
+  final base64Body = pulito.substring(_prefissoCodice.length);
+  final Map<String, dynamic> json;
+  try {
+    final jsonString = utf8.decode(base64Decode(base64Body));
+    json = jsonDecode(jsonString) as Map<String, dynamic>;
+  } catch (_) {
+    throw const FormatException('Codice corrotto o incompleto.');
+  }
+  return PGBase.fromJson(json);
+}
+
+String _nomeFileSicuro(String nome) {
+  final pulito = nome.trim().isEmpty ? 'personaggio' : nome.trim();
+  return pulito.replaceAll(RegExp(r'[^\w\-]+'), '_');
+}
+
+/// Scrive il codice di [pg] in un file temporaneo con estensione
+/// [estensioneFileEsportazione], da condividere con [Share.shareXFiles].
+/// Solo per piattaforme native (Android/iOS/desktop): su web non esiste il
+/// concetto di file scaricabile e riapribile con un tap, quindi va usata
+/// [esportaPersonaggio] con la condivisione testuale semplice.
+Future<File> creaFileEsportazione(PGBase pg) async {
+  final dir = await getTemporaryDirectory();
+  final nomeFile = '${_nomeFileSicuro(pg.nome)}$estensioneFileEsportazione';
+  final file = File('${dir.path}/$nomeFile');
+  return file.writeAsString(esportaPersonaggio(pg));
+}
+
+/// Legge un file esportato da [creaFileEsportazione] (es. ricevuto da
+/// un'altra app tramite receive_sharing_intent) e ricostruisce il
+/// [PGBase]. Lancia [FormatException] se il contenuto non e' un codice
+/// valido.
+Future<PGBase> importaPersonaggioDaFile(String percorso) async {
+  final contenuto = await File(percorso).readAsString();
+  return importaPersonaggio(contenuto);
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <open_file_linux/open_file_linux_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) open_file_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "OpenFileLinuxPlugin");
   open_file_linux_plugin_register_with_registrar(open_file_linux_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   open_file_linux
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,12 +7,14 @@ import Foundation
 
 import open_file_mac
 import path_provider_foundation
+import share_plus
 import shared_preferences_foundation
 import webview_flutter_wkwebview
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   OpenFilePlugin.register(with: registry.registrar(forPlugin: "OpenFilePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+4"
   crypto:
     dependency: transitive
     description:
@@ -141,10 +149,18 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -296,6 +312,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   nested:
     dependency: transitive
     description:
@@ -488,6 +512,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  receive_sharing_intent:
+    dependency: "direct main"
+    description:
+      name: receive_sharing_intent
+      sha256: "72f229a38f2910029c11d840770c173b27072e348ef3376130b37514bc4556f6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "9eee8283462d91a7a1c8bdb67d08874abd75a2f8fae3bc0ca033035e375fb3d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.2.0"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -621,6 +669,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: "direct main"
     description:
@@ -685,6 +765,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.26.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   google_mobile_ads: ^9.0.0
-
+  share_plus: ^13.2.0
+  receive_sharing_intent: ^1.9.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/character_share_test.dart
+++ b/test/character_share_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dnd_master_aid/factory_pg_base.dart';
+import 'package:dnd_master_aid/utils/character_share.dart';
+
+void main() {
+  PGBase creaPersonaggio() => PGBase(
+    nome: 'Elarion',
+    specie: 'Elfo',
+    classe: 'Mago',
+    livello: 3,
+    background: 'Saggio',
+    allineamento: 'Neutrale Buono',
+    competenze: const ['Arcano'],
+    caratteristiche: const {
+      'FOR': 8,
+      'DES': 14,
+      'COS': 12,
+      'INT': 16,
+      'SAG': 10,
+      'CAR': 10,
+    },
+    modificatori: const {
+      'FOR': -1,
+      'DES': 2,
+      'COS': 1,
+      'INT': 3,
+      'SAG': 0,
+      'CAR': 0,
+    },
+    caratteristicheImpostate: true,
+    velocita: 9,
+    linguaggi: const ['Comune', 'Elfico'],
+    capacitaSpeciali: const [],
+    dadoVita: 6,
+    puntiVita: 18,
+    tiriSalvezza: const ['Intelligenza', 'Saggezza'],
+    competenzeArmi: const [],
+    competenzeArmature: const [],
+    competenzeStrumenti: const [],
+    abilitaClasse: const [],
+    equipaggiamento: const ['Bastone Ferrato'],
+    denaroOro: 15,
+    proprietario: 'Marco',
+  );
+
+  test('esportaPersonaggio/importaPersonaggio fanno un round-trip fedele', () {
+    final originale = creaPersonaggio();
+    final codice = esportaPersonaggio(originale);
+    final importato = importaPersonaggio(codice);
+
+    expect(importato.id, originale.id);
+    expect(importato.nome, originale.nome);
+    expect(importato.classe, originale.classe);
+    expect(importato.livello, originale.livello);
+    expect(importato.caratteristiche, originale.caratteristiche);
+    expect(importato.proprietario, 'Marco');
+    expect(importato.denaroOro, 15);
+    expect(importato.equipaggiamento, originale.equipaggiamento);
+  });
+
+  test('esportaPersonaggio produce un codice con il prefisso atteso', () {
+    final codice = esportaPersonaggio(creaPersonaggio());
+    expect(codice.startsWith('DNDMA1:'), isTrue);
+  });
+
+  test('importaPersonaggio rifiuta un codice senza prefisso valido', () {
+    expect(
+      () => importaPersonaggio('qualcosa di a caso'),
+      throwsA(isA<FormatException>()),
+    );
+  });
+
+  test('importaPersonaggio rifiuta un base64 corrotto', () {
+    expect(
+      () => importaPersonaggio('DNDMA1:non-e-base64-valido!!!'),
+      throwsA(isA<FormatException>()),
+    );
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <share_plus/share_plus_windows_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,8 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  share_plus
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## Summary
Un giocatore crea il personaggio sul proprio dispositivo, ma il Master non ce l'ha: non c'era modo di far arrivare la scheda perché il Master la carichi tra "I Miei Personaggi".

- `lib/utils/character_share.dart`: `esportaPersonaggio`/`importaPersonaggio` (ri)codificano un `PGBase` in un codice testuale `DNDMA1:<base64 di toJson()>`; `creaFileEsportazione`/`importaPersonaggioDaFile` fanno lo stesso su file (solo piattaforme native)
- Pulsante "Condividi" nella scheda: apre il pannello di condivisione nativo del sistema (`share_plus`). Su web condivide il codice come testo semplice (il browser non ha il concetto di file "apri con"); su Android/iOS condivide un file **.dnd**
- `AndroidManifest.xml`: intent-filter `VIEW` per i file `.dnd` (vincolato via `pathPattern` per non comparire come "Apri con" su file qualsiasi), così un tap sul file ricevuto (es. da WhatsApp) apre direttamente l'app. `launchMode` passa a `singleTask` per evitare istanze duplicate dell'activity quando arriva un nuovo intent (raccomandazione esplicita del plugin)
- `main.dart`: ascolta `receive_sharing_intent` (file ricevuti mentre l'app è aperta o al cold start) e importa automaticamente il personaggio, con fallback silenzioso se il plugin non è supportato sulla piattaforma (web/desktop)
- Schermata "Importa scheda" (icona nell'app bar di "I Miei Personaggi"): incolla manualmente il codice ricevuto, utile su web o come fallback se il tap sul file non dovesse funzionare
- Nuovo campo `PGBase.proprietario`, editabile dalla scheda ("Di chi è questo personaggio"), per il Master che deve distinguere le schede di più giocatori

Chiude #49

## Note importanti
- **iOS**: il tap-to-open richiede una Share Extension (target Xcode separato, App Group, ecc.) non inclusa qui, coerentemente con la scelta già presa in questo progetto di rimandare il lavoro iOS
- **Non testato su un dispositivo Android reale**: in questo ambiente di sviluppo le build Android locali sono già rotte per un problema pre-esistente (incompatibilità JDK/Gradle, non collegato a questa PR) e non ho un tool di automazione browser per testare il flusso di condivisione end-to-end. L'intent-filter e il wiring di `receive_sharing_intent` seguono la documentazione ufficiale del plugin, ma **raccomando vivamente un test manuale su un vero telefono Android** prima di considerare completo il flusso "tap sul file → apre l'app" (WhatsApp in particolare ha compatibilità variabile con tipi di file non standard a seconda di versione Android/WhatsApp)

## Test plan
- [x] Nuovo `test/character_share_test.dart`: round-trip export/import fedele, prefisso codice, rifiuto codici non validi — verde
- [x] `flutter analyze` pulito
- [x] `flutter test` verde (11/11)
- [x] `flutter build web` completato senza errori (conferma che `dart:io`/receive_sharing_intent non rompono la build web, seguendo lo stesso pattern già usato in `step_export.dart`)
- [x] Screenshot: l'app si avvia correttamente su web senza errori nonostante il nuovo wiring di ascolto file condivisi
- [ ] Flusso "Condividi" → file `.dnd` → tap per riaprire → import automatico: non testabile in questo ambiente, da verificare manualmente