### PR TITLE
Rinomina il progetto da D&D Master Aid a Master Aid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# D&D Master Aid
+# Master Aid
 
-🎲 **D&D Master Aid** è un'app modulare OPEN SOURCE BETA per la creazione e gestione di personaggi Dungeons & Dragons 5e, pensata per essere leggera, responsive e perfetta sia per nuovi giocatori che per veterani del gioco di ruolo.
+🎲 **Master Aid** è un'app modulare OPEN SOURCE BETA pensata per essere un aiuto concreto ai master di giochi di ruolo. Al momento supporta **Dungeons & Dragons 5e** (creazione e gestione personaggi, scheda viva, tracker di combattimento), con l'obiettivo di aggiungere altri giochi in futuro, uno alla volta.
 
 ⚠️ **VERSIONE BETA** - App in sviluppo attivo con la community! Contributi benvenuti su GitHub.
 
@@ -99,8 +99,8 @@ Per utilizzare l'app, scarica semplicemente l'APK Android! Per lo sviluppo:
 
 ```bash
 # Clone del repository
-git clone https://github.com/tuo-username/DnD_MasterAid.git
-cd DnD_MasterAid
+git clone https://github.com/willskymaker/master_aid.git
+cd master_aid
 
 # Installazione dipendenze
 flutter pub get
@@ -148,7 +148,7 @@ flutter build web --release
 Il progetto è aperto a contributi! Puoi:
 - Aprire una Issue
 - Inviare una Pull Request
-- Segnalare bug o richieste via [GitHub Issues](https://github.com/tuo-username/DnD_MasterAid/issues)
+- Segnalare bug o richieste via [GitHub Issues](https://github.com/willskymaker/master_aid/issues)
 
 🎯 Issue "good first contribution"
 
@@ -205,7 +205,7 @@ Questo progetto è distribuito sotto licenza **MIT**. Consulta il file `LICENSE`
 **Status**: Progetto Open Source in sviluppo attivo
 
 **🔗 Collegamenti**:
-- **GitHub**: https://github.com/willskymaker/dnd_master_aid
+- **GitHub**: https://github.com/willskymaker/master_aid
 - **Google Play Store**: In pubblicazione
 - **FareZero Makers**: Supporto tecnico e community
 - **Licenza**: MIT License - Libero per tutti

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 android {
-    namespace = "com.dndmasteraid.app"
+    namespace = "com.masteraid.app"
     compileSdk = 35  // Alto per compilazione
     ndkVersion = "27.0.12077973"  // Versione richiesta dai plugin
 
@@ -37,7 +37,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.dndmasteraid.app"
+        applicationId = "com.masteraid.app"
         minSdk = 21
         targetSdk = 35  // Android 15 - richiesto da Google Play
         versionCode = flutter.versionCode

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
         tools:node="remove" />
 
     <application
-        android:label="D&amp;D Master Aid"
+        android:label="Master Aid"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="true"

--- a/android/app/src/main/kotlin/com/masteraid/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/masteraid/app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.dndmasteraid.app
+package com.masteraid.app
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.dndMasterAid;
+				PRODUCT_BUNDLE_IDENTIFIER = com.masteraid.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.dndMasterAid.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.masteraid.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.dndMasterAid.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.masteraid.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.dndMasterAid.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.masteraid.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.dndMasterAid;
+				PRODUCT_BUNDLE_IDENTIFIER = com.masteraid.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.dndMasterAid;
+				PRODUCT_BUNDLE_IDENTIFIER = com.masteraid.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>D&amp;D Master Aid</string>
+	<string>Master Aid</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>D&amp;D Master Aid</string>
+	<string>Master Aid</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,7 +15,7 @@ import 'screens/dice_roller.dart'; // Modulo dadi
 import 'screens/name_generator.dart'; // Generatore nomi (standalone)
 import 'screens/saved_characters_screen.dart'; // Lista personaggi salvati
 import 'screens/combat_tracker_screen.dart'; // Tracker iniziativa/combattimento
-import 'package:dnd_master_aid/factory_pg_base.dart';
+import 'factory_pg_base.dart';
 import 'providers/character_provider.dart';
 import 'providers/saved_characters_provider.dart';
 import 'utils/character_share.dart';
@@ -118,7 +118,7 @@ class _DnDMasterAidAppState extends State<DnDMasterAidApp> {
       ],
       child: MaterialApp(
         navigatorKey: _navigatorKey,
-        title: 'D&D Master Aid',
+        title: 'Master Aid',
         debugShowCheckedModeBanner: false,
         theme: buildAppTheme(),
         home: const HomePage(),
@@ -185,7 +185,7 @@ class HomePage extends StatelessWidget {
     final inArrivo = funzioni.where((f) => !(f['attivo'] as bool)).toList();
 
     return MobileScaffold(
-      title: 'D&D Master Aid',
+      title: 'Master Aid',
       showBackButton: false,
       leading: Padding(
         padding: const EdgeInsets.all(AppSpacing.sm),

--- a/lib/pg_base/steps/step_export.dart
+++ b/lib/pg_base/steps/step_export.dart
@@ -657,7 +657,7 @@ class _StepExportScreenState extends State<StepExportScreen> {
               pw.Divider(color: borderColor),
               pw.SizedBox(height: 4),
               pw.Text(
-                'D&D Master Aid  •  D&D 5e',
+                'Master Aid  •  D&D 5e',
                 style: pw.TextStyle(fontSize: 8, color: grey),
               ),
             ],

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -4,10 +4,10 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "dnd_master_aid")
+set(BINARY_NAME "master_aid")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.example.dnd_master_aid")
+set(APPLICATION_ID "com.example.master_aid")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -40,11 +40,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "dnd_master_aid");
+    gtk_header_bar_set_title(header_bar, "master_aid");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "dnd_master_aid");
+    gtk_window_set_title(window, "master_aid");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* dnd_master_aid.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "dnd_master_aid.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* master_aid.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "master_aid.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -131,7 +131,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* dnd_master_aid.app */,
+				33CC10ED2044A3C60003C045 /* master_aid.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -217,7 +217,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* dnd_master_aid.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* master_aid.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -385,10 +385,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.dndMasterAid.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.masteraid.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/dnd_master_aid.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/dnd_master_aid";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/master_aid.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/master_aid";
 			};
 			name = Debug;
 		};
@@ -399,10 +399,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.dndMasterAid.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.masteraid.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/dnd_master_aid.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/dnd_master_aid";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/master_aid.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/master_aid";
 			};
 			name = Release;
 		};
@@ -413,10 +413,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.dndMasterAid.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.masteraid.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/dnd_master_aid.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/dnd_master_aid";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/master_aid.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/master_aid";
 			};
 			name = Profile;
 		};

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "dnd_master_aid.app"
+               BuildableName = "master_aid.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "dnd_master_aid.app"
+            BuildableName = "master_aid.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "dnd_master_aid.app"
+            BuildableName = "master_aid.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "dnd_master_aid.app"
+            BuildableName = "master_aid.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,10 +5,10 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = dnd_master_aid
+PRODUCT_NAME = master_aid
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.example.dndMasterAid
+PRODUCT_BUNDLE_IDENTIFIER = com.masteraid.app
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
-name: dnd_master_aid
-description: "D&D Master Aid - Assistente open source offline per Dungeons & Dragons 5e: creazione personaggi, database specie/classi/incantesimi e strumenti per il Master."
+name: master_aid
+description: "Master Aid - Assistente open source offline per Master di giochi di ruolo. Attualmente supporta D&D 5e: creazione personaggi, database specie/classi/incantesimi e strumenti per il Master."
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev

--- a/test/character_share_test.dart
+++ b/test/character_share_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:dnd_master_aid/factory_pg_base.dart';
-import 'package:dnd_master_aid/utils/character_share.dart';
+import 'package:master_aid/factory_pg_base.dart';
+import 'package:master_aid/utils/character_share.dart';
 
 void main() {
   PGBase creaPersonaggio() => PGBase(

--- a/test/db_equip_test.dart
+++ b/test/db_equip_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:dnd_master_aid/data/db_equip.dart';
+import 'package:master_aid/data/db_equip.dart';
 
 void main() {
   group('classiConsigliatePerArma', () {

--- a/web/index.html
+++ b/web/index.html
@@ -18,18 +18,18 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="D&D Master Aid - Assistente open source offline per Dungeons & Dragons 5e.">
+  <meta name="description" content="Master Aid - Assistente open source offline per Master di giochi di ruolo. Attualmente supporta D&D 5e.">
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="D&D Master Aid">
+  <meta name="apple-mobile-web-app-title" content="Master Aid">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>D&D Master Aid</title>
+  <title>Master Aid</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,11 +1,11 @@
 {
-    "name": "D&D Master Aid",
-    "short_name": "D&D Master Aid",
+    "name": "Master Aid",
+    "short_name": "Master Aid",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#1a1a2e",
     "theme_color": "#1a1a2e",
-    "description": "Assistente open source offline per Dungeons & Dragons 5e: creazione personaggi, database e strumenti per il Master.",
+    "description": "Assistente open source offline per Master di giochi di ruolo. Attualmente supporta D&D 5e: creazione personaggi, database e strumenti per il Master.",
     "orientation": "portrait-primary",
     "prefer_related_applications": false,
     "icons": [

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(dnd_master_aid LANGUAGES CXX)
+project(master_aid LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "dnd_master_aid")
+set(BINARY_NAME "master_aid")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "dnd_master_aid" "\0"
+            VALUE "FileDescription", "master_aid" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "dnd_master_aid" "\0"
+            VALUE "InternalName", "master_aid" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
-            VALUE "OriginalFilename", "dnd_master_aid.exe" "\0"
-            VALUE "ProductName", "dnd_master_aid" "\0"
+            VALUE "OriginalFilename", "master_aid.exe" "\0"
+            VALUE "ProductName", "master_aid" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"dnd_master_aid", origin, size)) {
+  if (!window.Create(L"master_aid", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
## Summary
Primo passo verso l'obiettivo di diventare un aiuto generale per master di giochi di ruolo, aggiungendo un gioco alla volta (D&D 5e resta per ora l'unico contenuto supportato).

- Pacchetto Dart: `dnd_master_aid` → `master_aid` (pubspec.yaml e tutti gli import `package:` in `lib/` e `test/`)
- Android: `namespace`/`applicationId` `com.dndmasteraid.app` → `com.masteraid.app` (sicuro ora perché l'app non è ancora pubblicata su Play Store), spostata la directory Kotlin di conseguenza, aggiornata la label nel manifest
- iOS: bundle identifier e display name aggiornati per coerenza (iOS resta comunque fuori dallo sviluppo attivo)
- Desktop (windows/macos/linux): nomi prodotto/binario aggiornati per coerenza, anche se queste piattaforme non sono attivamente buildate/distribuite
- Branding: titolo app (MaterialApp e Home), web `manifest.json`/`index.html`, footer del PDF esportato
- README: titolo, descrizione, link al repo

Chiude #54

## Nota
Il repo GitHub verrà rinominato **dopo** il merge di questa PR (azione separata concordata con l'utente, che cambia l'URL del sito GitHub Pages da `willskymaker.github.io/dnd_master_aid/` a `willskymaker.github.io/master_aid/`).

## Test plan
- [x] `flutter analyze` pulito
- [x] `flutter test` verde (11/11), confermando che `package:master_aid/...` funziona nei test
- [x] `flutter build web` completato senza errori (dopo un `flutter clean` necessario per invalidare la cache del tool generata con il vecchio nome pacchetto)