### PR TITLE
Corregge il base-href del deploy web e ripulisce riferimenti residui

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -43,13 +43,13 @@ jobs:
 
     - name: Rename APK
       run: |
-        cp build/app/outputs/flutter-apk/app-release.apk dnd-master-aid-v${{ steps.version.outputs.VERSION }}.apk
+        cp build/app/outputs/flutter-apk/app-release.apk master-aid-v${{ steps.version.outputs.VERSION }}.apk
 
     - name: Upload APK Artifact
       uses: actions/upload-artifact@v4
       with:
         name: android-apk
-        path: dnd-master-aid-v${{ steps.version.outputs.VERSION }}.apk
+        path: master-aid-v${{ steps.version.outputs.VERSION }}.apk
 
     - name: Upload AAB Artifact
       uses: actions/upload-artifact@v4
@@ -64,9 +64,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref_name }}
-        release_name: D&D Master Aid ${{ github.ref_name }}
+        release_name: Master Aid ${{ github.ref_name }}
         body: |
-          🚀 **D&D Master Aid** - Nuova versione disponibile!
+          🚀 **Master Aid** - Nuova versione disponibile!
 
           ## 📱 Download Android
           - **APK**: Scarica e installa direttamente su Android
@@ -96,8 +96,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: dnd-master-aid-v${{ steps.version.outputs.VERSION }}.apk
-        asset_name: dnd-master-aid-v${{ steps.version.outputs.VERSION }}.apk
+        asset_path: master-aid-v${{ steps.version.outputs.VERSION }}.apk
+        asset_name: master-aid-v${{ steps.version.outputs.VERSION }}.apk
         asset_content_type: application/vnd.android.package-archive
 
     - name: Upload Release Asset (AAB)
@@ -108,5 +108,5 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: build/app/outputs/bundle/release/app-release.aab
-        asset_name: dnd-master-aid-v${{ steps.version.outputs.VERSION }}.aab
+        asset_name: master-aid-v${{ steps.version.outputs.VERSION }}.aab
         asset_content_type: application/octet-stream

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -21,7 +21,7 @@ jobs:
         run: flutter pub get
 
       - name: Build Web
-        run: flutter build web --base-href /dnd_master_aid/
+        run: flutter build web --base-href /master_aid/
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/APK_VERSIONS.md
+++ b/APK_VERSIONS.md
@@ -1,4 +1,4 @@
-# 📱 D&D Master Aid - Versioni APK
+# 📱 Master Aid - Versioni APK
 
 ## 🎯 Versione Consigliata
 

--- a/GOOGLE_PLAY_METADATA.md
+++ b/GOOGLE_PLAY_METADATA.md
@@ -1,9 +1,9 @@
-# 🎲 D&D Master Aid - Google Play Store Metadati
+# 🎲 Master Aid - Google Play Store Metadati
 
 ## 📱 Informazioni App
 
-**Nome App**: D&D Master Aid (BETA)
-**Package**: `com.dndmasteraid.app`
+**Nome App**: Master Aid (BETA)
+**Package**: `com.masteraid.app`
 **Versione**: 1.0.4 (Build 4) - VERSIONE BETA
 **Categoria**: Giochi / Ruolo / Strumenti
 **Classificazione**: Tutti (PEGI 3+)
@@ -13,13 +13,13 @@
 ---
 
 ## 📝 Descrizione Breve (50 caratteri)
-**D&D Master Aid BETA - Assistente Open Source**
+**Master Aid BETA - Assistente Open Source**
 
 ---
 
 ## 📖 Descrizione Completa
 
-**🎲 D&D Master Aid BETA - L'assistente Open Source per D&D 5e!**
+**🎲 Master Aid BETA - L'assistente Open Source per D&D 5e!**
 
 ⚠️ **VERSIONE BETA** - App in sviluppo attivo con la community!
 
@@ -81,7 +81,7 @@ Trasforma il tuo dispositivo mobile nel compagno perfetto per le tue avventure d
 Questa è una versione BETA in sviluppo attivo. Contenuti aggiornati regolarmente con nuove opzioni, correzioni e miglioramenti basati sui feedback della community. Il codice sorgente è disponibile su GitHub per contributi e revisioni.
 
 **🔗 GitHub Repository:**
-https://github.com/willskymaker/dnd_master_aid
+https://github.com/willskymaker/master_aid
 
 Scarica, testa e aiutaci a migliorare la tua esperienza D&D! Feedback e contributi benvenuti! 🏹✨
 
@@ -116,7 +116,7 @@ dungeons and dragons, d&d, 5e, rpg, gdr, gioco di ruolo, master, dm, dungeon mas
 - **Sviluppatore**: William Donzelli (alias Willskymaker)
 - **Collaborazione**: APS FareZero Makers FabLab
 - **GitHub**: https://github.com/willskymaker
-- **Repository**: https://github.com/willskymaker/dnd_master_aid
+- **Repository**: https://github.com/willskymaker/master_aid
 - **Email**: [da configurare per Google Play Console]
 - **Tipo**: Progetto Open Source Community-Driven
 - **Privacy Policy**: Inclusa nell'app - nessun dato raccolto

--- a/GUIDA_GOOGLE_PLAY_PUBBLICAZIONE.md
+++ b/GUIDA_GOOGLE_PLAY_PUBBLICAZIONE.md
@@ -36,7 +36,7 @@
 ## 📱 STEP 2: Creazione App su Console
 
 ### 2.1 Crea Nuova App
-1. **Nome App**: "D&D Master Aid"
+1. **Nome App**: "Master Aid"
 2. **Lingua Predefinita**: Italiano
 3. **Tipo App**: App (non Gioco - per evitare policy più rigide)
 4. **Gratuita**: Sì
@@ -61,7 +61,7 @@ Dimensioni: 16:9 o 9:16 ratio, minimo 320px
 **Da Creare:**
 1. **Home Screen** (1080x1920)
    - Dashboard principale con menu
-   - Mostra "D&D Master Aid" e icona
+   - Mostra "Master Aid" e icona
 
 2. **Database Specie** (1080x1920)
    - Lista razze con Elfo, Nano, Umano visibili
@@ -94,7 +94,7 @@ Dimensioni: 16:9 o 9:16 ratio, minimo 320px
 
 ### 3.2 Icona Feature Graphic
 - **Dimensione**: 1024x500 px
-- **Contenuto**: Logo + "D&D Master Aid BETA" + "Open Source"
+- **Contenuto**: Logo + "Master Aid BETA" + "Open Source"
 - **Formato**: PNG o JPG
 
 ---
@@ -103,7 +103,7 @@ Dimensioni: 16:9 o 9:16 ratio, minimo 320px
 
 ### 4.1 Descrizione Breve (80 caratteri)
 ```
-D&D Master Aid BETA - Assistente Open Source per Dungeons & Dragons 5e
+Master Aid BETA - Assistente Open Source per Dungeons & Dragons 5e
 ```
 
 ### 4.2 Descrizione Completa (4000 caratteri max)
@@ -122,7 +122,7 @@ strumenti, dadi, open source, beta, github, community
 
 ### 5.1 Privacy Policy
 ```
-D&D Master Aid - Privacy Policy
+Master Aid - Privacy Policy
 
 Ultima modifica: [DATA]
 
@@ -137,7 +137,7 @@ Tutti i dati sono memorizzati localmente sul dispositivo e non vengono mai trasm
 
 ## Contatti
 Sviluppatore: William Donzelli
-GitHub: https://github.com/willskymaker/dnd_master_aid
+GitHub: https://github.com/willskymaker/master_aid
 Email: [TUA EMAIL]
 
 ## Open Source

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 🎯 **Google Play Store**: In fase di pubblicazione (account sviluppatore in verifica)
 
 📥 **Download diretto APK**:
-- [**dnd-master-aid-v1.0.4-balanced.apk**](https://github.com/willskymaker/dnd_master_aid/releases/latest/download/dnd-master-aid-v1.0.4-balanced.apk) (25.8 MB) - **CONSIGLIATA**
-- [**dnd-master-aid-v1.0.4-googleplay-final.apk**](https://github.com/willskymaker/dnd_master_aid/releases/latest/download/dnd-master-aid-v1.0.4-googleplay-final.apk) (25.9 MB) - **Google Play Version**
+- [**dnd-master-aid-v1.0.4-balanced.apk**](https://github.com/willskymaker/master_aid/releases/latest/download/dnd-master-aid-v1.0.4-balanced.apk) (25.8 MB) - **CONSIGLIATA**
+- [**dnd-master-aid-v1.0.4-googleplay-final.apk**](https://github.com/willskymaker/master_aid/releases/latest/download/dnd-master-aid-v1.0.4-googleplay-final.apk) (25.9 MB) - **Google Play Version**
 
 ### 📋 Installazione Android
 


### PR DESCRIPTION
## Summary
- **Fix urgente**: il workflow `deploy-web.yml` aveva ancora `--base-href /dnd_master_aid/` hardcoded, non aggiornato durante la rinomina del repo in #55. Il deploy risultava "riuscito" ma i file JS venivano costruiti con percorsi che non esistono più al nuovo indirizzo (`willskymaker.github.io/master_aid/`), lasciando la pagina bianca. Segnalato dall'utente: "non visualizzo nulla https://willskymaker.github.io/master_aid/"
- Ripulisce i riferimenti al vecchio nome rimasti fuori dal giro precedente (perché fuori da `lib/` e dai file di piattaforma): `GOOGLE_PLAY_METADATA.md` (incluso il package name, ora allineato al nuovo `com.masteraid.app`), `GUIDA_GOOGLE_PLAY_PUBBLICAZIONE.md`, `APK_VERSIONS.md`, `README.md`, e il workflow di release Android (`android-release.yml`)
- Lasciati intenzionalmente invariati i nomi dei file APK già pubblicati in release passate (es. `dnd-master-aid-v1.0.4-balanced.apk`): sono nomi di file già esistenti su GitHub Releases, rinominare il testo del link non li rinominerebbe davvero

## Test plan
- [x] Verificato che nessun riferimento a `dnd_master_aid`/`dndmasteraid`/`D&D Master Aid` resti in file di configurazione, workflow o documentazione (`.claude/settings.local.json` escluso: non tracciato, gitignored)
- [x] `flutter analyze` pulito