### PR TITLE
Aggiunge suggerimenti tattici leggeri per i mostri nel tracker

### DIFF
--- a/lib/screens/combat_tracker_screen.dart
+++ b/lib/screens/combat_tracker_screen.dart
@@ -13,6 +13,7 @@ import '../providers/saved_characters_provider.dart';
 import '../repositories/json_data_repository.dart';
 import '../utils/encounter_generator.dart';
 import '../utils/loot_generator.dart';
+import '../utils/tactical_hints.dart';
 import '../widgets/mobile/mobile_scaffold.dart';
 import 'dice_roller.dart';
 import 'spell_cards_screen.dart';
@@ -683,6 +684,11 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
     final azioni = (dati['actions'] as List?) ?? const [];
     final azioniSpeciali = (dati['special_abilities'] as List?) ?? const [];
     final azioniLeggendarie = (dati['legendary_actions'] as List?) ?? const [];
+    final suggerimenti = suggerimentiTattici(
+      datiMostro: dati,
+      pfCorrenti: c.pfCorrenti,
+      pfMax: c.pfMax,
+    );
 
     const nomiCaratteristiche = {
       'strength': 'FOR',
@@ -749,6 +755,34 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
                                   ],
                                 );
                               }).toList(),
+                        ),
+                      ],
+                      if (suggerimenti.isNotEmpty) ...[
+                        const SizedBox(height: 16),
+                        Container(
+                          width: double.infinity,
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: AppColors.primary.withValues(alpha: 0.1),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Suggerimento',
+                                style: TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                  color: AppColors.primary,
+                                ),
+                              ),
+                              for (final s in suggerimenti)
+                                Padding(
+                                  padding: const EdgeInsets.only(top: 4),
+                                  child: Text('• $s'),
+                                ),
+                            ],
+                          ),
                         ),
                       ],
                       if (azioniSpeciali.isNotEmpty) ...[

--- a/lib/utils/tactical_hints.dart
+++ b/lib/utils/tactical_hints.dart
@@ -1,0 +1,50 @@
+/// Euristiche leggere (non IA vera) per suggerire al master come un mostro
+/// potrebbe comportarsi nel turno corrente, derivate solo da dati già
+/// presenti in monsters.json (caratteristiche, PF, testo delle azioni).
+library;
+
+List<String> suggerimentiTattici({
+  required Map<String, dynamic>? datiMostro,
+  required int pfCorrenti,
+  required int pfMax,
+}) {
+  if (datiMostro == null) return const [];
+
+  final suggerimenti = <String>[];
+
+  final abilityScores = datiMostro['ability_scores'] as Map?;
+  final saggezza = (abilityScores?['wisdom'] as num?)?.toInt();
+  final intelligenza = (abilityScores?['intelligence'] as num?)?.toInt();
+
+  if (saggezza != null &&
+      saggezza >= 12 &&
+      pfMax > 0 &&
+      pfCorrenti / pfMax < 0.3) {
+    suggerimenti.add('Potrebbe tentare di fuggire o rifugiarsi');
+  }
+
+  final azioni = [
+    ...((datiMostro['actions'] as List?) ?? const []),
+    ...((datiMostro['special_abilities'] as List?) ?? const []),
+  ];
+  final combattenteADistanza = azioni.any((a) {
+    if (a is! Map) return false;
+    if (a['range'] != null) return true;
+    final descrizione = (a['description'] as String? ?? '').toLowerCase();
+    return descrizione.contains('arma a distanza') ||
+        descrizione.contains('gittata');
+  });
+  if (combattenteADistanza) {
+    suggerimenti.add('Cerca di mantenere le distanze dai PG');
+  }
+
+  if (intelligenza != null) {
+    suggerimenti.add(
+      intelligenza >= 8
+          ? 'Punterebbe al PG più ferito/debole a portata'
+          : 'Attacca semplicemente il bersaglio più vicino',
+    );
+  }
+
+  return suggerimenti.take(2).toList();
+}

--- a/test/tactical_hints_test.dart
+++ b/test/tactical_hints_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:master_aid/utils/tactical_hints.dart';
+
+void main() {
+  group('suggerimentiTattici', () {
+    test('nessun dato mostro -> nessun suggerimento', () {
+      expect(
+        suggerimentiTattici(datiMostro: null, pfCorrenti: 5, pfMax: 10),
+        isEmpty,
+      );
+    });
+
+    test('SAG alta e PF sotto il 30% -> suggerisce fuga', () {
+      final suggerimenti = suggerimentiTattici(
+        datiMostro: {
+          'ability_scores': {'wisdom': 14, 'intelligence': 6},
+        },
+        pfCorrenti: 2,
+        pfMax: 10,
+      );
+      expect(
+        suggerimenti,
+        contains('Potrebbe tentare di fuggire o rifugiarsi'),
+      );
+    });
+
+    test('SAG alta ma PF sopra il 30% -> non suggerisce fuga', () {
+      final suggerimenti = suggerimentiTattici(
+        datiMostro: {
+          'ability_scores': {'wisdom': 14, 'intelligence': 6},
+        },
+        pfCorrenti: 8,
+        pfMax: 10,
+      );
+      expect(
+        suggerimenti,
+        isNot(contains('Potrebbe tentare di fuggire o rifugiarsi')),
+      );
+    });
+
+    test('INT >= 8 -> suggerisce targeting intelligente', () {
+      final suggerimenti = suggerimentiTattici(
+        datiMostro: {
+          'ability_scores': {'wisdom': 10, 'intelligence': 10},
+        },
+        pfCorrenti: 10,
+        pfMax: 10,
+      );
+      expect(
+        suggerimenti,
+        contains('Punterebbe al PG più ferito/debole a portata'),
+      );
+    });
+
+    test('INT < 8 -> suggerisce bersaglio più vicino', () {
+      final suggerimenti = suggerimentiTattici(
+        datiMostro: {
+          'ability_scores': {'wisdom': 10, 'intelligence': 4},
+        },
+        pfCorrenti: 10,
+        pfMax: 10,
+      );
+      expect(
+        suggerimenti,
+        contains('Attacca semplicemente il bersaglio più vicino'),
+      );
+    });
+
+    test('azione con gittata -> suggerisce di mantenere le distanze', () {
+      final suggerimenti = suggerimentiTattici(
+        datiMostro: {
+          'ability_scores': {'wisdom': 10, 'intelligence': 10},
+          'actions': [
+            {
+              'name': 'Shortbow',
+              'range': '80/320 ft',
+              'description': 'Attacco con arma a distanza: gittata 80/320 ft.',
+            },
+          ],
+        },
+        pfCorrenti: 10,
+        pfMax: 10,
+      );
+      expect(suggerimenti, contains('Cerca di mantenere le distanze dai PG'));
+    });
+
+    test('al massimo 2 suggerimenti', () {
+      final suggerimenti = suggerimentiTattici(
+        datiMostro: {
+          'ability_scores': {'wisdom': 16, 'intelligence': 10},
+          'actions': [
+            {'name': 'Shortbow', 'range': '80/320 ft', 'description': ''},
+          ],
+        },
+        pfCorrenti: 1,
+        pfMax: 10,
+      );
+      expect(suggerimenti.length, lessThanOrEqualTo(2));
+    });
+  });
+}


### PR DESCRIPTION
Chiude #73

## Cosa fa
- Nuova funzione pura `suggerimentiTattici` in `lib/utils/tactical_hints.dart`: dato `datiMostro` + PF correnti/massimi, ritorna 0-2 suggerimenti testuali brevi (non IA, solo euristiche):
  - SAG ≥ 12 e PF < 30% → possibile fuga/autoconservazione
  - Azione con `range` valorizzato o descrizione con "arma a distanza"/"gittata" → tenta di mantenere le distanze
  - INT ≥ 8 → punta al bersaglio più debole; INT < 8 → attacca il più vicino
- Sezione "Suggerimento" nella vista dettagli mostro del tracker (`_mostraDettagliMostro`), mostrata solo quando ci sono suggerimenti.
- Test unitari in `test/tactical_hints_test.dart` (7 casi).

## Verifica
- `flutter analyze` → nessun problema
- `flutter test` → tutti passano (18 test totali)
- `dart format --set-exit-if-changed .` → pulito