### PR TITLE
Aggiunge danni tipizzati con resistenze/immunità/vulnerabilità nel tracker

### DIFF
--- a/lib/screens/combat_tracker_screen.dart
+++ b/lib/screens/combat_tracker_screen.dart
@@ -11,6 +11,7 @@ import '../data/db_slot_incantesimi.dart';
 import '../factory_pg_base.dart';
 import '../providers/saved_characters_provider.dart';
 import '../repositories/json_data_repository.dart';
+import '../utils/damage_types.dart';
 import '../utils/encounter_generator.dart';
 import '../utils/loot_generator.dart';
 import '../utils/tactical_hints.dart';
@@ -330,6 +331,87 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
         c.tsMorteFallimenti = 0;
       }
     });
+  }
+
+  Future<void> _mostraApplicaDanno(_Combattente c) async {
+    final dannoController = TextEditingController();
+    String? tipoSelezionato;
+
+    final confermato = await showDialog<bool>(
+      context: context,
+      builder: (ctx) {
+        return StatefulBuilder(
+          builder: (ctx, setDialogState) {
+            return AlertDialog(
+              title: Text('Applica danno a ${c.nome}'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextField(
+                    controller: dannoController,
+                    autofocus: true,
+                    keyboardType: TextInputType.number,
+                    decoration: const InputDecoration(
+                      labelText: 'Quantità di danno',
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  DropdownButtonFormField<String?>(
+                    initialValue: tipoSelezionato,
+                    decoration: const InputDecoration(
+                      labelText: 'Tipo di danno (opzionale)',
+                    ),
+                    items: [
+                      const DropdownMenuItem<String?>(
+                        value: null,
+                        child: Text('Nessuno (danno pieno)'),
+                      ),
+                      for (final tipo in tipiDanno)
+                        DropdownMenuItem<String?>(
+                          value: tipo,
+                          child: Text(tipo),
+                        ),
+                    ],
+                    onChanged: (v) => setDialogState(() => tipoSelezionato = v),
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(ctx, false),
+                  child: const Text('Annulla'),
+                ),
+                FilledButton(
+                  onPressed: () => Navigator.pop(ctx, true),
+                  child: const Text('Applica'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    if (confermato != true) return;
+    final danno = int.tryParse(dannoController.text) ?? 0;
+    if (danno <= 0) return;
+
+    if (tipoSelezionato == null) {
+      _modificaPf(c, -danno);
+      return;
+    }
+
+    final risultato = applicaResistenze(
+      danno: danno,
+      tipoDannoItaliano: tipoSelezionato!,
+      datiMostro: c.datiMostro,
+    );
+    _modificaPf(c, -risultato.dannoApplicato);
+    if (risultato.messaggio != null && mounted) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(risultato.messaggio!)));
+    }
   }
 
   /// Tira un TS contro la morte per un combattente a 0 PF: 20 naturale
@@ -1186,6 +1268,14 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
                                     color: AppColors.primary,
                                     tooltip: 'Slot incantesimo',
                                   ),
+                                IconButton(
+                                  onPressed: () => _mostraApplicaDanno(c),
+                                  icon: const Icon(
+                                    Icons.local_fire_department_outlined,
+                                  ),
+                                  color: Colors.deepOrange,
+                                  tooltip: 'Applica danno tipizzato',
+                                ),
                                 IconButton(
                                   onPressed: () => _modificaPf(c, -1),
                                   icon: const Icon(Icons.remove_circle_outline),

--- a/lib/utils/damage_types.dart
+++ b/lib/utils/damage_types.dart
@@ -1,0 +1,103 @@
+/// I 13 tipi di danno ufficiali D&D 5e, in italiano.
+const List<String> tipiDanno = [
+  'Contundente',
+  'Perforante',
+  'Tagliente',
+  'Acido',
+  'Freddo',
+  'Fuoco',
+  'Forza',
+  'Fulmine',
+  'Necrotico',
+  'Veleno',
+  'Psichico',
+  'Radiante',
+  'Tuono',
+];
+
+/// Parola chiave inglese usata in monsters.json per ciascun tipo di danno,
+/// da cercare (case-insensitive, come sottostringa) nei campi
+/// damage_resistances/damage_immunities/damage_vulnerabilities.
+const Map<String, String> _tipoDannoInglese = {
+  'Contundente': 'bludgeoning',
+  'Perforante': 'piercing',
+  'Tagliente': 'slashing',
+  'Acido': 'acid',
+  'Freddo': 'cold',
+  'Fuoco': 'fire',
+  'Forza': 'force',
+  'Fulmine': 'lightning',
+  'Necrotico': 'necrotic',
+  'Veleno': 'poison',
+  'Psichico': 'psychic',
+  'Radiante': 'radiant',
+  'Tuono': 'thunder',
+};
+
+class RisultatoDanno {
+  final int dannoApplicato;
+  final String? messaggio;
+
+  const RisultatoDanno({required this.dannoApplicato, this.messaggio});
+}
+
+/// Applica resistenza/immunità/vulnerabilità di [datiMostro] (se presente)
+/// a un danno di tipo [tipoDannoItaliano], secondo le regole D&D 5e:
+/// immunità -> 0 danno, resistenza -> danno dimezzato (arrotondato per
+/// difetto), vulnerabilità -> danno raddoppiato. Se il mostro ha sia
+/// resistenza che vulnerabilità allo stesso tipo si annullano a vicenda
+/// (danno pieno), come da regolamento.
+RisultatoDanno applicaResistenze({
+  required int danno,
+  required String tipoDannoItaliano,
+  required Map<String, dynamic>? datiMostro,
+}) {
+  if (datiMostro == null) {
+    return RisultatoDanno(dannoApplicato: danno);
+  }
+  final chiave = _tipoDannoInglese[tipoDannoItaliano];
+  if (chiave == null) {
+    return RisultatoDanno(dannoApplicato: danno);
+  }
+
+  bool contiene(String campo) {
+    final lista = datiMostro[campo] as List?;
+    if (lista == null) return false;
+    return lista.any((v) => v.toString().toLowerCase().contains(chiave));
+  }
+
+  final immune = contiene('damage_immunities');
+  final resistente = contiene('damage_resistances');
+  final vulnerabile = contiene('damage_vulnerabilities');
+
+  if (immune) {
+    return RisultatoDanno(
+      dannoApplicato: 0,
+      messaggio: 'Immune a $tipoDannoItaliano: nessun danno',
+    );
+  }
+  if (resistente && vulnerabile) {
+    return RisultatoDanno(
+      dannoApplicato: danno,
+      messaggio:
+          'Resistente e vulnerabile a $tipoDannoItaliano: si annullano, danno pieno',
+    );
+  }
+  if (resistente) {
+    final dimezzato = danno ~/ 2;
+    return RisultatoDanno(
+      dannoApplicato: dimezzato,
+      messaggio:
+          'Resistente a $tipoDannoItaliano: danno dimezzato a $dimezzato',
+    );
+  }
+  if (vulnerabile) {
+    final raddoppiato = danno * 2;
+    return RisultatoDanno(
+      dannoApplicato: raddoppiato,
+      messaggio:
+          'Vulnerabile a $tipoDannoItaliano: danno raddoppiato a $raddoppiato',
+    );
+  }
+  return RisultatoDanno(dannoApplicato: danno);
+}

--- a/test/damage_types_test.dart
+++ b/test/damage_types_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:master_aid/utils/damage_types.dart';
+
+void main() {
+  group('applicaResistenze', () {
+    test('nessun dato mostro -> danno pieno', () {
+      final r = applicaResistenze(
+        danno: 10,
+        tipoDannoItaliano: 'Fuoco',
+        datiMostro: null,
+      );
+      expect(r.dannoApplicato, 10);
+      expect(r.messaggio, isNull);
+    });
+
+    test('immunità -> nessun danno', () {
+      final r = applicaResistenze(
+        danno: 10,
+        tipoDannoItaliano: 'Veleno',
+        datiMostro: {
+          'damage_immunities': ['poison'],
+        },
+      );
+      expect(r.dannoApplicato, 0);
+      expect(r.messaggio, contains('Immune'));
+    });
+
+    test('resistenza -> danno dimezzato arrotondato per difetto', () {
+      final r = applicaResistenze(
+        danno: 11,
+        tipoDannoItaliano: 'Fuoco',
+        datiMostro: {
+          'damage_resistances': ['fire'],
+        },
+      );
+      expect(r.dannoApplicato, 5);
+      expect(r.messaggio, contains('dimezzato'));
+    });
+
+    test('vulnerabilità -> danno raddoppiato', () {
+      final r = applicaResistenze(
+        danno: 6,
+        tipoDannoItaliano: 'Contundente',
+        datiMostro: {
+          'damage_vulnerabilities': ['bludgeoning'],
+        },
+      );
+      expect(r.dannoApplicato, 12);
+      expect(r.messaggio, contains('raddoppiato'));
+    });
+
+    test('resistenza + vulnerabilità stesso tipo -> si annullano', () {
+      final r = applicaResistenze(
+        danno: 8,
+        tipoDannoItaliano: 'Freddo',
+        datiMostro: {
+          'damage_resistances': ['cold'],
+          'damage_vulnerabilities': ['cold'],
+        },
+      );
+      expect(r.dannoApplicato, 8);
+      expect(r.messaggio, contains('annullano'));
+    });
+
+    test('resistenza con testo import "sporco" (virgole spezzate)', () {
+      final r = applicaResistenze(
+        danno: 10,
+        tipoDannoItaliano: 'Tagliente',
+        datiMostro: {
+          'damage_resistances': [
+            'lightning',
+            'thunder; bludgeoning',
+            'piercing',
+            'and slashing from nonmagical attacks',
+          ],
+        },
+      );
+      expect(r.dannoApplicato, 5);
+    });
+
+    test('tipo di danno non riconosciuto -> danno pieno', () {
+      final r = applicaResistenze(
+        danno: 10,
+        tipoDannoItaliano: 'Sconosciuto',
+        datiMostro: {
+          'damage_immunities': ['fire'],
+        },
+      );
+      expect(r.dannoApplicato, 10);
+    });
+
+    test(
+      'nessuna resistenza/immunità/vulnerabilità per quel tipo -> danno pieno',
+      () {
+        final r = applicaResistenze(
+          danno: 10,
+          tipoDannoItaliano: 'Fuoco',
+          datiMostro: {
+            'damage_immunities': ['poison'],
+          },
+        );
+        expect(r.dannoApplicato, 10);
+        expect(r.messaggio, isNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Chiude #72

## Cosa fa
- Nuova funzione pura `applicaResistenze` in `lib/utils/damage_types.dart`: dato un danno, un tipo (i 13 tipi ufficiali D&D 5e) e i dati del mostro, applica immunità (0 danno), resistenza (dimezzato, arrotondato per difetto) o vulnerabilità (raddoppiato) leggendo `damage_resistances`/`damage_immunities`/`damage_vulnerabilities` da `monsters.json` (già presenti, mai usati finora). Gestisce anche il caso resistenza+vulnerabilità sullo stesso tipo (si annullano, RAW) e il testo "sporco" dell'import (virgole spezzate in liste tipo `['thunder; bludgeoning', 'piercing', ...]`) via match a sottostringa.
- Nuovo pulsante "Applica danno tipizzato" (icona fiamma) accanto ai controlli PF nel tracker: apre un dialog con quantità + tipo di danno opzionale, mostra un feedback (es. "Resistente al fuoco: danno dimezzato a 6") e applica il danno corretto.
- Senza tipo selezionato, comportamento invariato (danno pieno).
- Test unitari in `test/damage_types_test.dart` (8 casi).

## Verifica
- `flutter analyze` → nessun problema
- `flutter test` → tutti passano (26 test totali)
- `dart format --set-exit-if-changed .` → pulito