### PR TITLE
Corregge l'icona Vista Giocatori invisibile perché mimetizzata nell'AppBar

### DIFF
--- a/lib/screens/combat_tracker_screen.dart
+++ b/lib/screens/combat_tracker_screen.dart
@@ -1077,7 +1077,12 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
           icon: Icon(
             _vistaGiocatori ? Icons.visibility : Icons.visibility_outlined,
           ),
-          color: _vistaGiocatori ? AppColors.primary : null,
+          style:
+              _vistaGiocatori
+                  ? IconButton.styleFrom(
+                    backgroundColor: Colors.white.withValues(alpha: 0.25),
+                  )
+                  : null,
           tooltip: 'Vista Giocatori',
         ),
         if (!_vistaGiocatori)


### PR DESCRIPTION
Chiude #89

## Cosa fa
- Il pulsante Vista Giocatori esisteva sempre e restava funzionante, ma quando attivo il suo colore era impostato a `AppColors.primary` — identico allo sfondo dell'AppBar, quindi invisibile (screenshot dell'utente: AppBar apparentemente vuota nella vista attiva).
- Rimosso il tint colorato: l'icona resta sempre bianca, lo stato attivo è comunicato dall'icona piena (👁) vs contornata e da un piccolo sfondo circolare semi-trasparente.

## Verifica
- `flutter analyze` → nessun problema
- `flutter test` → tutti passano (32 test totali)
- `dart format --set-exit-if-changed .` → pulito