### PR TITLE
Aggiunge le specie D&D come fonte nomi principale nel Generatore PNG

### DIFF
--- a/lib/screens/npc_generator_screen.dart
+++ b/lib/screens/npc_generator_screen.dart
@@ -13,11 +13,11 @@ class NpcGeneratorScreen extends StatefulWidget {
 }
 
 class _NpcGeneratorScreenState extends State<NpcGeneratorScreen> {
-  String _tema = nomiPerTema.keys.first;
+  String _fonteNomi = nomiPerSpecie.keys.first;
   Png? _png;
 
   void _genera() {
-    setState(() => _png = generaPng(tema: _tema));
+    setState(() => _png = generaPng(fonteNomi: _fonteNomi));
   }
 
   Widget _sezione(String titolo, String testo) {
@@ -40,6 +40,31 @@ class _NpcGeneratorScreenState extends State<NpcGeneratorScreen> {
     );
   }
 
+  Widget _gruppoChip(String etichetta, Iterable<String> voci) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          etichetta,
+          style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+        ),
+        const SizedBox(height: 4),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            for (final voce in voci)
+              ChoiceChip(
+                label: Text(voce),
+                selected: _fonteNomi == voce,
+                onSelected: (_) => setState(() => _fonteNomi = voce),
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final png = _png;
@@ -51,18 +76,9 @@ class _NpcGeneratorScreenState extends State<NpcGeneratorScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: [
-                for (final tema in nomiPerTema.keys)
-                  ChoiceChip(
-                    label: Text(tema),
-                    selected: _tema == tema,
-                    onSelected: (_) => setState(() => _tema = tema),
-                  ),
-              ],
-            ),
+            _gruppoChip('Specie D&D', nomiPerSpecie.keys),
+            const SizedBox(height: AppSpacing.md),
+            _gruppoChip('Temi extra', nomiPerTema.keys),
             const SizedBox(height: AppSpacing.lg),
             ElevatedButton.icon(
               onPressed: _genera,

--- a/lib/utils/npc_generator.dart
+++ b/lib/utils/npc_generator.dart
@@ -19,13 +19,14 @@ class Png {
   });
 }
 
-/// Genera un PNG "usa e getta" combinando un nome a tema (vedi
-/// [nomiPerTema]) con aspetto fisico, personalità, occupazione e un gancio
-/// di trama pescati casualmente dalle tabelle in db_npc.dart.
-Png generaPng({required String tema, Random? random}) {
+/// Genera un PNG "usa e getta" combinando un nome (da una specie D&D, vedi
+/// [nomiPerSpecie], o da un tema extra, vedi [nomiPerTema]) con aspetto
+/// fisico, personalità, occupazione e un gancio di trama pescati
+/// casualmente dalle tabelle in db_npc.dart.
+Png generaPng({required String fonteNomi, Random? random}) {
   final rnd = random ?? Random();
   return Png(
-    nome: _generaNome(tema, rnd),
+    nome: _generaNome(fonteNomi, rnd),
     aspetto: aspettiFisiciNpc[rnd.nextInt(aspettiFisiciNpc.length)],
     personalita: trattiPersonalitaNpc[rnd.nextInt(trattiPersonalitaNpc.length)],
     occupazione: occupazioniNpc[rnd.nextInt(occupazioniNpc.length)],
@@ -33,8 +34,8 @@ Png generaPng({required String tema, Random? random}) {
   );
 }
 
-String _generaNome(String tema, Random rnd) {
-  final nomiBase = nomiPerTema[tema];
+String _generaNome(String fonteNomi, Random rnd) {
+  final nomiBase = nomiPerSpecie[fonteNomi] ?? nomiPerTema[fonteNomi];
   if (nomiBase == null) return 'Sconosciuto';
 
   final lista = rnd.nextBool() ? nomiBase.maschili : nomiBase.femminili;

--- a/test/npc_generator_test.dart
+++ b/test/npc_generator_test.dart
@@ -6,9 +6,9 @@ import 'package:master_aid/utils/npc_generator.dart';
 
 void main() {
   group('generaPng', () {
-    test('genera tutti i campi non vuoti per ogni tema disponibile', () {
-      for (final tema in nomiPerTema.keys) {
-        final png = generaPng(tema: tema, random: Random(42));
+    test('genera tutti i campi non vuoti per ogni specie D&D disponibile', () {
+      for (final specie in nomiPerSpecie.keys) {
+        final png = generaPng(fonteNomi: specie, random: Random(42));
         expect(png.nome, isNotEmpty);
         expect(png.aspetto, isNotEmpty);
         expect(png.personalita, isNotEmpty);
@@ -17,15 +17,22 @@ void main() {
       }
     });
 
-    test('tema sconosciuto -> nome di fallback, resto sempre popolato', () {
-      final png = generaPng(tema: 'Non Esiste', random: Random(1));
+    test('genera tutti i campi non vuoti per ogni tema extra disponibile', () {
+      for (final tema in nomiPerTema.keys) {
+        final png = generaPng(fonteNomi: tema, random: Random(42));
+        expect(png.nome, isNotEmpty);
+      }
+    });
+
+    test('fonte sconosciuta -> nome di fallback, resto sempre popolato', () {
+      final png = generaPng(fonteNomi: 'Non Esiste', random: Random(1));
       expect(png.nome, 'Sconosciuto');
       expect(png.aspetto, isNotEmpty);
     });
 
     test('con lo stesso seed produce sempre lo stesso risultato', () {
-      final png1 = generaPng(tema: 'Pirata', random: Random(7));
-      final png2 = generaPng(tema: 'Pirata', random: Random(7));
+      final png1 = generaPng(fonteNomi: 'Elfo', random: Random(7));
+      final png2 = generaPng(fonteNomi: 'Elfo', random: Random(7));
       expect(png1.nome, png2.nome);
       expect(png1.aspetto, png2.aspetto);
       expect(png1.personalita, png2.personalita);
@@ -36,7 +43,7 @@ void main() {
     test('seed diversi producono variazione', () {
       final risultati = <String>{};
       for (var i = 0; i < 10; i++) {
-        risultati.add(generaPng(tema: 'Fantascienza', random: Random(i)).nome);
+        risultati.add(generaPng(fonteNomi: 'Umano', random: Random(i)).nome);
       }
       expect(risultati.length, greaterThan(1));
     });


### PR DESCRIPTION
Chiude #93

## Cosa fa
- `generaPng` accetta ora `fonteNomi` (rinominato da `tema`), che cerca prima in `nomiPerSpecie` (Umano, Elfo, Nano, Halfling, Dragonide, Gnomo, Tiefling, Mezzelfo, Mezzorco) e poi in `nomiPerTema` (Pirata/Lovecraft/Fantascienza/Moderno) — stesso approccio già usato dal Generatore Nomi standalone.
- La schermata mostra due gruppi di chip separati: "Specie D&D" (selezionata di default) e "Temi extra".
- Test aggiornati per coprire entrambe le fonti.

## Verifica
- `flutter analyze` → nessun problema
- `flutter test` → tutti passano (37 test totali)
- `dart format --set-exit-if-changed .` → pulito