### PR TITLE
Aggiunge Impostazioni Master per disattivare PG casuale e barra vita mostri

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,9 +16,11 @@ import 'screens/name_generator.dart'; // Generatore nomi (standalone)
 import 'screens/npc_generator_screen.dart'; // Generatore PNG completo
 import 'screens/saved_characters_screen.dart'; // Lista personaggi salvati
 import 'screens/combat_tracker_screen.dart'; // Tracker iniziativa/combattimento
+import 'screens/settings_screen.dart'; // Impostazioni del Master
 import 'factory_pg_base.dart';
 import 'providers/character_provider.dart';
 import 'providers/saved_characters_provider.dart';
+import 'providers/settings_provider.dart';
 import 'utils/character_share.dart';
 import 'widgets/banner_ad_widget.dart';
 import 'widgets/mobile/mobile_scaffold.dart';
@@ -116,6 +118,7 @@ class _DnDMasterAidAppState extends State<DnDMasterAidApp> {
       providers: [
         ChangeNotifierProvider(create: (_) => CharacterProvider()),
         ChangeNotifierProvider(create: (_) => SavedCharactersProvider()),
+        ChangeNotifierProvider(create: (_) => SettingsProvider()..carica()),
       ],
       child: MaterialApp(
         navigatorKey: _navigatorKey,
@@ -202,6 +205,17 @@ class HomePage extends StatelessWidget {
           child: Image.asset('assets/icon/icon.png'),
         ),
       ),
+      actions: [
+        IconButton(
+          onPressed:
+              () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const SettingsScreen()),
+              ),
+          icon: const Icon(Icons.settings),
+          tooltip: 'Impostazioni',
+        ),
+      ],
       body: Column(
         children: [
           Expanded(

--- a/lib/pg_base/steps/step_abilita.dart
+++ b/lib/pg_base/steps/step_abilita.dart
@@ -1,12 +1,14 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../../core/app_theme.dart';
 import '../../factory_pg_base.dart';
 import '../../data/db_abilita.dart';
 import '../../data/db_classi.dart';
 import '../../core/logger.dart';
 import '../../core/exceptions.dart';
+import '../../providers/settings_provider.dart';
 import '../../widgets/mobile/mobile_scaffold.dart';
 
 class StepAbilitaScreen extends StatefulWidget {
@@ -94,6 +96,8 @@ class _StepAbilitaScreenState extends State<StepAbilitaScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final randomizzazionePgAttiva =
+        context.watch<SettingsProvider>().randomizzazionePgAttiva;
     final selezionate = abilitaSelezionate.length;
     final completo = selezionate == maxAbilita;
     final coloreCounter =
@@ -207,15 +211,17 @@ class _StepAbilitaScreenState extends State<StepAbilitaScreen> {
             ),
             child: Column(
               children: [
-                SizedBox(
-                  width: double.infinity,
-                  child: OutlinedButton.icon(
-                    onPressed: _randomizza,
-                    icon: const Icon(Icons.casino),
-                    label: const Text('Abilità casuali'),
+                if (randomizzazionePgAttiva) ...[
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton.icon(
+                      onPressed: _randomizza,
+                      icon: const Icon(Icons.casino),
+                      label: const Text('Abilità casuali'),
+                    ),
                   ),
-                ),
-                const SizedBox(height: AppSpacing.sm),
+                  const SizedBox(height: AppSpacing.sm),
+                ],
                 SizedBox(
                   width: double.infinity,
                   child: ElevatedButton(

--- a/lib/pg_base/steps/step_background.dart
+++ b/lib/pg_base/steps/step_background.dart
@@ -1,10 +1,12 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../../core/app_theme.dart';
 import '../../factory_pg_base.dart';
 import '../../data/db_background.dart';
 import '../../data/db_allineamenti.dart';
+import '../../providers/settings_provider.dart';
 import '../../widgets/mobile/mobile_scaffold.dart';
 
 class StepBackgroundScreen extends StatefulWidget {
@@ -74,6 +76,9 @@ class _StepBackgroundScreenState extends State<StepBackgroundScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final randomizzazionePgAttiva =
+        context.watch<SettingsProvider>().randomizzazionePgAttiva;
+
     return MobileScaffold(
       title: 'Step: Background e Allineamento',
       body: Column(
@@ -92,15 +97,17 @@ class _StepBackgroundScreenState extends State<StepBackgroundScreen> {
                   style: TextStyle(fontSize: 13, color: Colors.grey.shade600),
                 ),
                 const SizedBox(height: 12),
-                SizedBox(
-                  width: double.infinity,
-                  child: OutlinedButton.icon(
-                    onPressed: _randomizza,
-                    icon: const Icon(Icons.casino),
-                    label: const Text('Background e allineamento casuali'),
+                if (randomizzazionePgAttiva) ...[
+                  SizedBox(
+                    width: double.infinity,
+                    child: OutlinedButton.icon(
+                      onPressed: _randomizza,
+                      icon: const Icon(Icons.casino),
+                      label: const Text('Background e allineamento casuali'),
+                    ),
                   ),
-                ),
-                const SizedBox(height: 16),
+                  const SizedBox(height: 16),
+                ],
                 ...backgroundList.map(
                   (bg) => _BackgroundCard(
                     bg: bg,

--- a/lib/pg_base/steps/step_caratteristiche.dart
+++ b/lib/pg_base/steps/step_caratteristiche.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../../core/app_theme.dart';
 import '../../factory_pg_base.dart';
 import '../../data/db_classi.dart';
@@ -8,6 +9,7 @@ import '../utils/pf_helper.dart';
 import '../utils/asi_helper.dart';
 import '../../core/logger.dart';
 import '../../core/exceptions.dart';
+import '../../providers/settings_provider.dart';
 import '../../widgets/mobile/mobile_scaffold.dart';
 
 final List<int> standardArray = [15, 14, 13, 12, 10, 8];
@@ -187,6 +189,8 @@ class _StepCaratteristicheScreenState extends State<StepCaratteristicheScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final randomizzazionePgAttiva =
+        context.watch<SettingsProvider>().randomizzazionePgAttiva;
     final rimanenti = _puntiRimanenti;
     final coloreRimanenti =
         rimanenti < 0
@@ -252,22 +256,23 @@ class _StepCaratteristicheScreenState extends State<StepCaratteristicheScreen> {
               ],
             ),
           ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(
-              AppSpacing.lg,
-              AppSpacing.sm,
-              AppSpacing.lg,
-              0,
-            ),
-            child: SizedBox(
-              width: double.infinity,
-              child: OutlinedButton.icon(
-                onPressed: _randomizza,
-                icon: const Icon(Icons.casino),
-                label: const Text('Distribuisci punti casualmente'),
+          if (randomizzazionePgAttiva)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.lg,
+                AppSpacing.sm,
+                AppSpacing.lg,
+                0,
+              ),
+              child: SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: _randomizza,
+                  icon: const Icon(Icons.casino),
+                  label: const Text('Distribuisci punti casualmente'),
+                ),
               ),
             ),
-          ),
           // Lista caratteristiche
           Expanded(
             child: ListView(

--- a/lib/pg_base/steps/step_classe.dart
+++ b/lib/pg_base/steps/step_classe.dart
@@ -1,9 +1,11 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../../core/app_theme.dart';
 import '../../factory_pg_base.dart';
 import '../../data/db_classi.dart';
+import '../../providers/settings_provider.dart';
 import '../../widgets/mobile/mobile_scaffold.dart';
 
 final List<String> classiCore = [
@@ -30,22 +32,25 @@ class StepClasseScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final classiDisponibili =
         classiList.where((c) => classiCore.contains(c.nome)).toList();
+    final randomizzazionePgAttiva =
+        context.watch<SettingsProvider>().randomizzazionePgAttiva;
 
     return MobileScaffold(
       title: "Step 2: Scegli la Classe",
       body: Column(
         children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-            child: SizedBox(
-              width: double.infinity,
-              child: OutlinedButton.icon(
-                onPressed: () => _randomizza(context, classiDisponibili),
-                icon: const Icon(Icons.casino),
-                label: const Text('Classe casuale'),
+          if (randomizzazionePgAttiva)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+              child: SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: () => _randomizza(context, classiDisponibili),
+                  icon: const Icon(Icons.casino),
+                  label: const Text('Classe casuale'),
+                ),
               ),
             ),
-          ),
           Expanded(
             child: ListView.builder(
               itemCount: classiDisponibili.length,

--- a/lib/pg_base/steps/step_equip.dart
+++ b/lib/pg_base/steps/step_equip.dart
@@ -1,8 +1,10 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../../factory_pg_base.dart';
 import '../../data/db_equip.dart';
+import '../../providers/settings_provider.dart';
 import '../../repositories/json_data_repository.dart';
 
 class StepEquipScreen extends StatefulWidget {
@@ -126,6 +128,8 @@ class _StepEquipScreenState extends State<StepEquipScreen> {
   @override
   Widget build(BuildContext context) {
     final classePG = widget.factory.build().classe;
+    final randomizzazionePgAttiva =
+        context.watch<SettingsProvider>().randomizzazionePgAttiva;
 
     return Scaffold(
       appBar: AppBar(title: const Text("Step: Equipaggiamento")),
@@ -260,15 +264,17 @@ class _StepEquipScreenState extends State<StepEquipScreen> {
                       ),
                       const SizedBox(height: 32),
 
-                      SizedBox(
-                        width: double.infinity,
-                        child: OutlinedButton.icon(
-                          onPressed: _randomizza,
-                          icon: const Icon(Icons.casino),
-                          label: const Text("Equipaggiamento casuale"),
+                      if (randomizzazionePgAttiva) ...[
+                        SizedBox(
+                          width: double.infinity,
+                          child: OutlinedButton.icon(
+                            onPressed: _randomizza,
+                            icon: const Icon(Icons.casino),
+                            label: const Text("Equipaggiamento casuale"),
+                          ),
                         ),
-                      ),
-                      const SizedBox(height: 8),
+                        const SizedBox(height: 8),
+                      ],
                       SizedBox(
                         width: double.infinity,
                         child: ElevatedButton(

--- a/lib/pg_base/steps/step_livello.dart
+++ b/lib/pg_base/steps/step_livello.dart
@@ -1,8 +1,10 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../../core/app_theme.dart';
 import '../../factory_pg_base.dart';
+import '../../providers/settings_provider.dart';
 import '../../widgets/mobile/mobile_scaffold.dart';
 
 class StepLivelloScreen extends StatefulWidget {
@@ -42,6 +44,9 @@ class _StepLivelloScreenState extends State<StepLivelloScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final randomizzazionePgAttiva =
+        context.watch<SettingsProvider>().randomizzazionePgAttiva;
+
     return MobileScaffold(
       title: "Step: Seleziona il Livello",
       body: Padding(
@@ -69,12 +74,14 @@ class _StepLivelloScreenState extends State<StepLivelloScreen> {
                 ),
               ),
             ),
-            const SizedBox(height: AppSpacing.lg),
-            OutlinedButton.icon(
-              onPressed: _randomizza,
-              icon: const Icon(Icons.casino),
-              label: const Text("Livello casuale"),
-            ),
+            if (randomizzazionePgAttiva) ...[
+              const SizedBox(height: AppSpacing.lg),
+              OutlinedButton.icon(
+                onPressed: _randomizza,
+                icon: const Icon(Icons.casino),
+                label: const Text("Livello casuale"),
+              ),
+            ],
             const SizedBox(height: AppSpacing.lg),
             ElevatedButton(
               onPressed: _conferma,

--- a/lib/pg_base/steps/step_specie.dart
+++ b/lib/pg_base/steps/step_specie.dart
@@ -1,8 +1,10 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../../factory_pg_base.dart';
 import '../../data/db_specie.dart'; //importa il database specie
+import '../../providers/settings_provider.dart';
 import '../../widgets/mobile/mobile_scaffold.dart';
 
 class StepSpecieScreen extends StatelessWidget {
@@ -12,21 +14,25 @@ class StepSpecieScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final randomizzazionePgAttiva =
+        context.watch<SettingsProvider>().randomizzazionePgAttiva;
+
     return MobileScaffold(
       title: "Step 1: Seleziona la Specie",
       body: Column(
         children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-            child: SizedBox(
-              width: double.infinity,
-              child: OutlinedButton.icon(
-                onPressed: () => _randomizza(context),
-                icon: const Icon(Icons.casino),
-                label: const Text('Specie casuale'),
+          if (randomizzazionePgAttiva)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+              child: SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: () => _randomizza(context),
+                  icon: const Icon(Icons.casino),
+                  label: const Text('Specie casuale'),
+                ),
               ),
             ),
-          ),
           Expanded(
             child: ListView.builder(
               itemCount: specieCoreList.length,

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Impostazioni del Master per attivare/disattivare funzionalita' che
+/// possono far somigliare Master Aid a un videogioco piu' che a un gdr.
+/// Disattivate di default: il Master le attiva solo se le vuole al tavolo.
+class SettingsProvider extends ChangeNotifier {
+  static const _chiaveRandomizzazionePg = 'settings_randomizzazione_pg';
+  static const _chiaveBarraSaluteMostri = 'settings_barra_salute_mostri';
+
+  bool _randomizzazionePgAttiva = false;
+  bool _barraSaluteMostriAttiva = false;
+
+  bool get randomizzazionePgAttiva => _randomizzazionePgAttiva;
+  bool get barraSaluteMostriAttiva => _barraSaluteMostriAttiva;
+
+  Future<void> carica() async {
+    final prefs = await SharedPreferences.getInstance();
+    _randomizzazionePgAttiva = prefs.getBool(_chiaveRandomizzazionePg) ?? false;
+    _barraSaluteMostriAttiva = prefs.getBool(_chiaveBarraSaluteMostri) ?? false;
+    notifyListeners();
+  }
+
+  Future<void> setRandomizzazionePg(bool attiva) async {
+    _randomizzazionePgAttiva = attiva;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_chiaveRandomizzazionePg, attiva);
+  }
+
+  Future<void> setBarraSaluteMostri(bool attiva) async {
+    _barraSaluteMostriAttiva = attiva;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_chiaveBarraSaluteMostri, attiva);
+  }
+}

--- a/lib/screens/combat_tracker_screen.dart
+++ b/lib/screens/combat_tracker_screen.dart
@@ -10,6 +10,7 @@ import '../data/db_condizioni.dart';
 import '../data/db_slot_incantesimi.dart';
 import '../factory_pg_base.dart';
 import '../providers/saved_characters_provider.dart';
+import '../providers/settings_provider.dart';
 import '../repositories/json_data_repository.dart';
 import '../utils/damage_types.dart';
 import '../utils/encounter_generator.dart';
@@ -1068,24 +1069,28 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
     final inCorso = ordinati.isNotEmpty;
     final turnoCorrente =
         inCorso ? ordinati[_turnoIndex % ordinati.length] : null;
+    final barraSaluteMostriAttiva =
+        context.watch<SettingsProvider>().barraSaluteMostriAttiva;
+    final vistaGiocatori = _vistaGiocatori && barraSaluteMostriAttiva;
 
     return MobileScaffold(
       title: 'Tracker Combattimento',
       actions: [
-        IconButton(
-          onPressed: () => setState(() => _vistaGiocatori = !_vistaGiocatori),
-          icon: Icon(
-            _vistaGiocatori ? Icons.visibility : Icons.visibility_outlined,
+        if (barraSaluteMostriAttiva)
+          IconButton(
+            onPressed: () => setState(() => _vistaGiocatori = !_vistaGiocatori),
+            icon: Icon(
+              vistaGiocatori ? Icons.visibility : Icons.visibility_outlined,
+            ),
+            style:
+                vistaGiocatori
+                    ? IconButton.styleFrom(
+                      backgroundColor: Colors.white.withValues(alpha: 0.25),
+                    )
+                    : null,
+            tooltip: 'Vista Giocatori',
           ),
-          style:
-              _vistaGiocatori
-                  ? IconButton.styleFrom(
-                    backgroundColor: Colors.white.withValues(alpha: 0.25),
-                  )
-                  : null,
-          tooltip: 'Vista Giocatori',
-        ),
-        if (!_vistaGiocatori)
+        if (!vistaGiocatori)
           PopupMenuButton<String>(
             tooltip: 'Altre azioni',
             onSelected: (azione) {
@@ -1168,7 +1173,7 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
           ),
       ],
       floatingActionButton:
-          _vistaGiocatori
+          vistaGiocatori
               ? null
               : FloatingActionButton.extended(
                 onPressed: _mostraAggiungiCombattente,
@@ -1277,7 +1282,7 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
                                 Expanded(
                                   child: InkWell(
                                     onTap:
-                                        _vistaGiocatori
+                                        vistaGiocatori
                                             ? null
                                             : () => _modificaCombattente(c),
                                     child: Column(
@@ -1290,7 +1295,7 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
                                             fontWeight: FontWeight.bold,
                                           ),
                                         ),
-                                        if (_vistaGiocatori && !c.isPg)
+                                        if (vistaGiocatori && !c.isPg)
                                           Padding(
                                             padding: const EdgeInsets.only(
                                               top: 4,
@@ -1307,7 +1312,7 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
                                           Text(
                                             '${c.isPg ? "PG" : "Mostro"}'
                                             '${c.ca != null ? " · CA ${c.ca}" : ""}'
-                                            '${!_vistaGiocatori && c.cd != null ? " · CD ${c.cd}" : ""}'
+                                            '${!vistaGiocatori && c.cd != null ? " · CD ${c.cd}" : ""}'
                                             ' · PF ${c.pfCorrenti}/${c.pfMax}',
                                             style: TextStyle(
                                               fontSize: 12,
@@ -1361,7 +1366,7 @@ class _CombatTrackerScreenState extends State<CombatTrackerScreen> {
                                     ),
                                   ),
                                 ),
-                                if (!_vistaGiocatori) ...[
+                                if (!vistaGiocatori) ...[
                                   if (c.datiMostro != null)
                                     IconButton(
                                       onPressed: () => _mostraDettagliMostro(c),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../core/app_theme.dart';
+import '../providers/settings_provider.dart';
+import '../widgets/mobile/mobile_scaffold.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = context.watch<SettingsProvider>();
+
+    return MobileScaffold(
+      title: 'Impostazioni',
+      body: ListView(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        children: [
+          Text(
+            'Alcune funzioni sono pensate per velocizzare il gioco, ma '
+            'possono far somigliare Master Aid a un videogioco più che a un '
+            'gdr. Il Master può disattivarle per tenere il tavolo più fedele '
+            'alle regole classiche.',
+            style: Theme.of(
+              context,
+            ).textTheme.bodyMedium?.copyWith(color: AppColors.textSecondary),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          SwitchListTile(
+            title: const Text('Costruzione PG casuale'),
+            subtitle: const Text(
+              'Mostra i pulsanti "casuale" nella creazione guidata del '
+              'personaggio (specie, classe, livello, caratteristiche, '
+              'abilità, background, equipaggiamento).',
+            ),
+            value: settings.randomizzazionePgAttiva,
+            activeThumbColor: AppColors.primary,
+            onChanged: settings.setRandomizzazionePg,
+          ),
+          const Divider(),
+          SwitchListTile(
+            title: const Text('Barra vita mostri (Vista Giocatori)'),
+            subtitle: const Text(
+              'Permette di mostrare ai giocatori una fascia di salute dei '
+              'mostri nel Tracker Combattimento, invece di gestire i PF '
+              'solo a voce.',
+            ),
+            value: settings.barraSaluteMostriAttiva,
+            activeThumbColor: AppColors.primary,
+            onChanged: settings.setBarraSaluteMostri,
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Cosa fa

Aggiunge una schermata Impostazioni con due interruttori che il Master può usare per disattivare funzionalità che rischiano di far somigliare Master Aid a un videogioco più che a un gdr classico:

- **Costruzione PG casuale**: nasconde i pulsanti "casuale" nei singoli step della creazione guidata del personaggio (specie, classe, livello, caratteristiche, abilità, background, equipaggiamento).
- **Barra vita mostri (Vista Giocatori)**: nasconde l'icona che attiva la Vista Giocatori nel Tracker Combattimento (fascia di salute dei mostri mostrata ai giocatori invece dei PF esatti gestiti a voce).

Entrambe le opzioni sono **disattivate di default**: il Master le attiva esplicitamente dalle Impostazioni se le vuole al tavolo.

## Come

- `SettingsProvider` (ChangeNotifier + SharedPreferences) espone i due flag, persistiti tra le sessioni.
- Registrato in `main.dart` accanto agli altri provider; icona ⚙️ in home per raggiungere `SettingsScreen`.
- Ogni step del wizard (`lib/pg_base/steps/step_*.dart`) legge `randomizzazionePgAttiva` da `context.watch<SettingsProvider>()` e nasconde condizionalmente il pulsante "casuale".
- `combat_tracker_screen.dart`: l'icona Vista Giocatori è visibile solo se `barraSaluteMostriAttiva`; se l'impostazione viene disattivata mentre la Vista Giocatori è già attiva, il tracker torna comunque alla vista normale (PF esatti) grazie a una variabile locale `vistaGiocatori = _vistaGiocatori && barraSaluteMostriAttiva`.

## Verifica

- `flutter analyze` → nessun problema
- `flutter test` → tutti i 37 test passano
- `dart format --set-exit-if-changed .` → pulito
- Non sono riuscito a lanciare la build Linux desktop in locale per una verifica visiva (manca una libreria di sistema richiesta da `audioplayers_linux`, limite dell'ambiente non legato a questa modifica)
