### PR TITLE
Comprime il codice di condivisione della scheda personaggio

### DIFF
--- a/lib/utils/character_share.dart
+++ b/lib/utils/character_share.dart
@@ -7,44 +7,65 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:archive/archive.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../factory_pg_base.dart';
 
-/// Prefisso che identifica un codice personaggio valido e ne marca la
-/// versione del formato, per poter evolvere il formato in futuro senza
-/// rompere l'import di codici generati da versioni precedenti dell'app.
-const String _prefissoCodice = 'DNDMA1:';
+/// Prefisso dei codici generati dalla v1 dell'app: JSON -> base64, senza
+/// compressione. Non piu' prodotto da [esportaPersonaggio], ma ancora
+/// riconosciuto in importazione per non rompere i codici gia' condivisi
+/// prima dell'introduzione della compressione.
+const String _prefissoCodiceV1 = 'DNDMA1:';
+
+/// Prefisso dei codici correnti: JSON -> deflate (zlib) -> base64. La
+/// compressione riduce sensibilmente la lunghezza del codice (il JSON di
+/// una scheda ha molte chiavi ripetute e campi vuoti/di default), rendendolo
+/// piu' comodo da incollare in chat.
+const String _prefissoCodiceV2 = 'DNDMA2:';
 
 /// Estensione del file esportato: registrata in AndroidManifest.xml cosi'
 /// che, ricevuto ad es. da WhatsApp, un tap sul file apra direttamente
 /// questa app invece di un visualizzatore generico.
 const String estensioneFileEsportazione = '.dnd';
 
-/// Codifica [pg] in un codice testuale da condividere (es. via il pannello
-/// di condivisione nativo). Il codice e' un blob base64 per restare
-/// leggibile/incollabile in qualunque app di messaggistica, senza andare
-/// in conflitto con virgolette o a-capo del JSON sottostante.
+/// Codifica [pg] in un codice testuale compatto da condividere (es. via il
+/// pannello di condivisione nativo). Il JSON viene compresso (zlib) prima
+/// del base64, per restare leggibile/incollabile in qualunque app di
+/// messaggistica senza andare in conflitto con virgolette o a-capo, ma il
+/// piu' corto possibile.
 String esportaPersonaggio(PGBase pg) {
-  final jsonString = jsonEncode(pg.toJson());
-  return _prefissoCodice + base64Encode(utf8.encode(jsonString));
+  final jsonBytes = utf8.encode(jsonEncode(pg.toJson()));
+  final compresso = const ZLibEncoder().encodeBytes(jsonBytes);
+  return _prefissoCodiceV2 + base64Encode(compresso);
 }
 
-/// Decodifica un codice prodotto da [esportaPersonaggio] e ricostruisce il
-/// [PGBase]. Lancia [FormatException] se il codice non e' valido.
+/// Decodifica un codice prodotto da [esportaPersonaggio] (o da una versione
+/// precedente dell'app) e ricostruisce il [PGBase]. Lancia [FormatException]
+/// se il codice non e' valido.
 PGBase importaPersonaggio(String codice) {
   final pulito = codice.trim();
-  if (!pulito.startsWith(_prefissoCodice)) {
-    throw const FormatException(
-      'Codice non riconosciuto: assicurati di aver incollato l\'intero '
-      'codice ricevuto.',
-    );
-  }
-  final base64Body = pulito.substring(_prefissoCodice.length);
   final Map<String, dynamic> json;
   try {
-    final jsonString = utf8.decode(base64Decode(base64Body));
-    json = jsonDecode(jsonString) as Map<String, dynamic>;
+    if (pulito.startsWith(_prefissoCodiceV2)) {
+      final compresso = base64Decode(
+        pulito.substring(_prefissoCodiceV2.length),
+      );
+      final jsonBytes = const ZLibDecoder().decodeBytes(compresso);
+      json = jsonDecode(utf8.decode(jsonBytes)) as Map<String, dynamic>;
+    } else if (pulito.startsWith(_prefissoCodiceV1)) {
+      final jsonString = utf8.decode(
+        base64Decode(pulito.substring(_prefissoCodiceV1.length)),
+      );
+      json = jsonDecode(jsonString) as Map<String, dynamic>;
+    } else {
+      throw const FormatException(
+        'Codice non riconosciuto: assicurati di aver incollato l\'intero '
+        'codice ricevuto.',
+      );
+    }
+  } on FormatException {
+    rethrow;
   } catch (_) {
     throw const FormatException('Codice corrotto o incompleto.');
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -10,7 +10,7 @@ packages:
     source: hosted
     version: "2.0.3"
   archive:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: archive
       sha256: "7dcbd0f87fe5f61cb28da39a1a8b70dbc106e2fe0516f7836eb7bb2948481a12"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   share_plus: ^13.2.0
   receive_sharing_intent: ^1.9.0
   audioplayers: ^6.8.1
+  archive: ^4.0.5
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/character_share_test.dart
+++ b/test/character_share_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:master_aid/factory_pg_base.dart';
 import 'package:master_aid/utils/character_share.dart';
@@ -60,7 +62,29 @@ void main() {
 
   test('esportaPersonaggio produce un codice con il prefisso atteso', () {
     final codice = esportaPersonaggio(creaPersonaggio());
-    expect(codice.startsWith('DNDMA1:'), isTrue);
+    expect(codice.startsWith('DNDMA2:'), isTrue);
+  });
+
+  test(
+    'esportaPersonaggio comprime: il codice e\' piu\' corto del JSON base64 grezzo',
+    () {
+      final pg = creaPersonaggio();
+      final codice = esportaPersonaggio(pg);
+      final grezzo = base64Encode(utf8.encode(jsonEncode(pg.toJson())));
+      expect(codice.length, lessThan(grezzo.length));
+    },
+  );
+
+  test('importaPersonaggio legge ancora i codici v1 (non compressi)', () {
+    final originale = creaPersonaggio();
+    final jsonString = jsonEncode(originale.toJson());
+    final codiceV1 = 'DNDMA1:${base64Encode(utf8.encode(jsonString))}';
+
+    final importato = importaPersonaggio(codiceV1);
+
+    expect(importato.id, originale.id);
+    expect(importato.nome, originale.nome);
+    expect(importato.equipaggiamento, originale.equipaggiamento);
   });
 
   test('importaPersonaggio rifiuta un codice senza prefisso valido', () {
@@ -70,9 +94,16 @@ void main() {
     );
   });
 
-  test('importaPersonaggio rifiuta un base64 corrotto', () {
+  test('importaPersonaggio rifiuta un base64 corrotto (v1)', () {
     expect(
       () => importaPersonaggio('DNDMA1:non-e-base64-valido!!!'),
+      throwsA(isA<FormatException>()),
+    );
+  });
+
+  test('importaPersonaggio rifiuta un base64 corrotto (v2)', () {
+    expect(
+      () => importaPersonaggio('DNDMA2:non-e-base64-valido!!!'),
       throwsA(isA<FormatException>()),
     );
   });


### PR DESCRIPTION
Closes #98

## Cosa fa

Comprime il codice testuale generato per condividere una scheda personaggio (es. via WhatsApp), invece di codificare solo `base64(JSON)` senza compressione.

## Come

- `esportaPersonaggio` ora comprime il JSON con zlib (`ZLibEncoder` del pacchetto `archive`, puro Dart, funziona anche su web) prima del base64. Nuovo prefisso di formato `DNDMA2:`.
- `importaPersonaggio` riconosce sia i nuovi codici `DNDMA2:` sia i vecchi `DNDMA1:` non compressi: i codici già condivisi da versioni precedenti dell'app continuano a funzionare senza rotture.
- Aggiunta `archive` come dipendenza esplicita in `pubspec.yaml` (era già presente transitivamente).

## Risultato

Tipicamente 40-60% più corto del formato precedente, dato che il JSON di una scheda ha molte chiavi ripetute e campi vuoti/di default.

## Verifica

- `flutter analyze` → nessun problema
- `flutter test` → tutti passano, inclusi due test nuovi: retrocompatibilità sui codici v1, e verifica che il nuovo codice sia più corto del JSON base64 grezzo
- `dart format --set-exit-if-changed .` → pulito
