### PR TITLE
Aggiunge Generatore Side Quest e PNG salvabili tra le sessioni

### DIFF
--- a/lib/data/db_side_quest.dart
+++ b/lib/data/db_side_quest.dart
@@ -1,0 +1,49 @@
+/// Tabelle di elementi per il generatore di side quest: combinati danno
+/// una missione secondaria abbozzata, pronta per l'improvvisazione o per
+/// arricchire una sessione. Segue lo stesso principio del generatore PNG
+/// (vedi db_npc.dart).
+const List<String> obiettiviSideQuest = [
+  'Recuperare un oggetto rubato da una banda locale',
+  'Scortare qualcuno attraverso una zona pericolosa',
+  'Investigare una serie di sparizioni sospette',
+  'Eliminare una minaccia che infesta i dintorni',
+  'Consegnare un messaggio o un pacco riservato',
+  'Trovare una persona scomparsa da giorni',
+  'Sabotare un\'operazione illecita prima che vada a segno',
+  'Negoziare una tregua tra due fazioni rivali',
+  'Recuperare informazioni infiltrandosi in un luogo sorvegliato',
+  'Proteggere qualcuno da un attentato imminente',
+  'Scoprire la verità dietro una voce che circola in città',
+  'Ripulire un\'area infestata da creature moleste',
+  'Recuperare un debito che nessun altro osa riscuotere',
+  'Scortare un carico di valore fino a destinazione',
+  'Rompere una maledizione che affligge una famiglia o un luogo',
+];
+
+const List<String> complicazioniSideQuest = [
+  'Il vero colpevole è qualcuno di cui nessuno sospetterebbe',
+  'La missione è in realtà una trappola tesa da un rivale',
+  'Un secondo gruppo persegue lo stesso obiettivo, in competizione diretta',
+  'Le informazioni iniziali erano parzialmente false o incomplete',
+  'C\'è un limite di tempo più stretto del previsto',
+  'Un alleato inatteso si rivela un ostacolo, o viceversa',
+  'L\'obiettivo richiede di scegliere tra due mali minori',
+  'Qualcuno di innocente rischia di pagare le conseguenze',
+  'Serve un oggetto o un permesso che nessuno vuole concedere facilmente',
+  'La situazione è più grave di come è stata inizialmente descritta',
+  'Un vecchio debito o legame del gruppo torna a galla proprio ora',
+  'Le autorità locali ostacolano invece di aiutare',
+];
+
+const List<String> ricompenseSideQuest = [
+  'Una somma in monete, negoziabile se la missione riesce bene',
+  'Un oggetto magico minore, di dubbia provenienza',
+  'Un favore da riscuotere in futuro, senza scadenza',
+  'Informazioni preziose su un pericolo più grande',
+  'Accesso a un luogo o una fazione altrimenti chiusa',
+  'La gratitudine pubblica, con conseguente reputazione in città',
+  'Uno sconto permanente presso un\'attività locale',
+  'La consegna di equipaggiamento o materiali rari',
+  'Un alleato che si unisce alla causa del gruppo',
+  'Un indizio che collega la missione a una trama più ampia',
+];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'screens/npc_generator_screen.dart'; // Generatore PNG completo
 import 'screens/saved_characters_screen.dart'; // Lista personaggi salvati
 import 'screens/combat_tracker_screen.dart'; // Tracker iniziativa/combattimento
 import 'screens/settings_screen.dart'; // Impostazioni del Master
+import 'screens/side_quest_generator_screen.dart'; // Generatore side quest
 import 'factory_pg_base.dart';
 import 'providers/character_provider.dart';
 import 'providers/saved_characters_provider.dart';
@@ -182,6 +183,13 @@ class HomePage extends StatelessWidget {
       'nome': 'Generatore PNG',
       'icona': '🎭',
       'descr': 'PNG usa e getta per l\'improvvisazione',
+      'attivo': true,
+    },
+    {
+      'id': 'sideQuest',
+      'nome': 'Generatore Side Quest',
+      'icona': '📜',
+      'descr': 'Missioni secondarie pronte per l\'improvvisazione',
       'attivo': true,
     },
   ];
@@ -444,6 +452,9 @@ class HomePage extends StatelessWidget {
         break;
       case 'pngGenerator':
         page = const NpcGeneratorScreen();
+        break;
+      case 'sideQuest':
+        page = const SideQuestGeneratorScreen();
         break;
       default:
         page = const ComingSoonScreen(); // 🕒 Placeholder

--- a/lib/screens/npc_generator_screen.dart
+++ b/lib/screens/npc_generator_screen.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 
 import '../core/app_theme.dart';
 import '../data/db_nomi.dart';
+import '../services/saved_npc_service.dart';
 import '../utils/npc_generator.dart';
 import '../widgets/mobile/mobile_scaffold.dart';
+import 'saved_npcs_screen.dart';
 
 class NpcGeneratorScreen extends StatefulWidget {
   const NpcGeneratorScreen({super.key});
@@ -15,9 +17,24 @@ class NpcGeneratorScreen extends StatefulWidget {
 class _NpcGeneratorScreenState extends State<NpcGeneratorScreen> {
   String _fonteNomi = nomiPerSpecie.keys.first;
   Png? _png;
+  bool _salvato = false;
 
   void _genera() {
-    setState(() => _png = generaPng(fonteNomi: _fonteNomi));
+    setState(() {
+      _png = generaPng(fonteNomi: _fonteNomi);
+      _salvato = false;
+    });
+  }
+
+  Future<void> _salvaPng() async {
+    final png = _png;
+    if (png == null) return;
+    await SavedNpcService.salva(png);
+    if (!mounted) return;
+    setState(() => _salvato = true);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('${png.nome} salvato tra i PNG della campagna')),
+    );
   }
 
   Widget _sezione(String titolo, String testo) {
@@ -71,6 +88,17 @@ class _NpcGeneratorScreenState extends State<NpcGeneratorScreen> {
 
     return MobileScaffold(
       title: 'Generatore PNG',
+      actions: [
+        IconButton(
+          onPressed:
+              () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const SavedNpcsScreen()),
+              ),
+          icon: const Icon(Icons.people_alt_outlined),
+          tooltip: 'PNG salvati',
+        ),
+      ],
       body: Padding(
         padding: const EdgeInsets.all(AppSpacing.lg),
         child: Column(
@@ -103,6 +131,18 @@ class _NpcGeneratorScreenState extends State<NpcGeneratorScreen> {
                       _sezione('Personalità', png.personalita),
                       _sezione('Occupazione', png.occupazione),
                       _sezione('Gancio di trama', png.ganceTrama),
+                      const SizedBox(height: AppSpacing.md),
+                      OutlinedButton.icon(
+                        onPressed: _salvato ? null : _salvaPng,
+                        icon: Icon(
+                          _salvato ? Icons.check : Icons.bookmark_add_outlined,
+                        ),
+                        label: Text(
+                          _salvato
+                              ? 'Salvato tra i PNG della campagna'
+                              : 'Salva per riusarlo in altre sessioni',
+                        ),
+                      ),
                     ],
                   ),
                 ),

--- a/lib/screens/saved_npcs_screen.dart
+++ b/lib/screens/saved_npcs_screen.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+
+import '../core/app_theme.dart';
+import '../services/saved_npc_service.dart';
+import '../utils/npc_generator.dart';
+import '../widgets/mobile/mobile_scaffold.dart';
+
+/// Elenco dei PNG salvati dal Master, da riusare in sessioni future della
+/// stessa campagna (es. come committente ricorrente di una side quest).
+class SavedNpcsScreen extends StatefulWidget {
+  const SavedNpcsScreen({super.key});
+
+  @override
+  State<SavedNpcsScreen> createState() => _SavedNpcsScreenState();
+}
+
+class _SavedNpcsScreenState extends State<SavedNpcsScreen> {
+  List<Png> _png = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _carica();
+  }
+
+  Future<void> _carica() async {
+    final png = await SavedNpcService.caricaTutti();
+    if (!mounted) return;
+    setState(() {
+      _png = png;
+      _loading = false;
+    });
+  }
+
+  Future<void> _elimina(Png png) async {
+    await SavedNpcService.elimina(png.id);
+    if (!mounted) return;
+    setState(() => _png.removeWhere((p) => p.id == png.id));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text('${png.nome} eliminato')));
+  }
+
+  void _mostraDettagli(Png png) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder:
+          (_) => Padding(
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(png.nome, style: Theme.of(context).textTheme.titleLarge),
+                  const SizedBox(height: AppSpacing.md),
+                  _sezione('Aspetto', png.aspetto),
+                  _sezione('Personalità', png.personalita),
+                  _sezione('Occupazione', png.occupazione),
+                  _sezione('Gancio di trama', png.ganceTrama),
+                  const SizedBox(height: AppSpacing.md),
+                ],
+              ),
+            ),
+          ),
+    );
+  }
+
+  Widget _sezione(String titolo, String testo) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            titolo,
+            style: const TextStyle(
+              fontWeight: FontWeight.bold,
+              color: AppColors.primary,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(testo),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MobileScaffold(
+      title: 'PNG salvati',
+      body:
+          _loading
+              ? const Center(child: CircularProgressIndicator())
+              : _png.isEmpty
+              ? const Center(
+                child: Padding(
+                  padding: EdgeInsets.all(AppSpacing.lg),
+                  child: Text(
+                    'Nessun PNG salvato. Generane uno e salvalo per '
+                    'ritrovarlo qui nelle prossime sessioni della campagna.',
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              )
+              : ListView.builder(
+                padding: const EdgeInsets.all(AppSpacing.md),
+                itemCount: _png.length,
+                itemBuilder: (context, index) {
+                  final png = _png[index];
+                  return Card(
+                    margin: const EdgeInsets.only(bottom: AppSpacing.sm),
+                    child: ListTile(
+                      title: Text(png.nome),
+                      subtitle: Text(
+                        png.occupazione,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      onTap: () => _mostraDettagli(png),
+                      trailing: IconButton(
+                        icon: const Icon(Icons.delete_outline),
+                        onPressed: () => _elimina(png),
+                        tooltip: 'Elimina',
+                      ),
+                    ),
+                  );
+                },
+              ),
+    );
+  }
+}

--- a/lib/screens/side_quest_generator_screen.dart
+++ b/lib/screens/side_quest_generator_screen.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+
+import '../core/app_theme.dart';
+import '../services/saved_npc_service.dart';
+import '../utils/npc_generator.dart';
+import '../utils/side_quest_generator.dart';
+import '../widgets/mobile/mobile_scaffold.dart';
+
+class SideQuestGeneratorScreen extends StatefulWidget {
+  const SideQuestGeneratorScreen({super.key});
+
+  @override
+  State<SideQuestGeneratorScreen> createState() =>
+      _SideQuestGeneratorScreenState();
+}
+
+class _SideQuestGeneratorScreenState extends State<SideQuestGeneratorScreen> {
+  List<Png> _pngSalvati = [];
+  Png? _committenteScelto;
+  SideQuest? _quest;
+
+  @override
+  void initState() {
+    super.initState();
+    _caricaPngSalvati();
+  }
+
+  Future<void> _caricaPngSalvati() async {
+    final png = await SavedNpcService.caricaTutti();
+    if (!mounted) return;
+    setState(() => _pngSalvati = png);
+  }
+
+  void _genera() {
+    setState(() => _quest = generaSideQuest(committente: _committenteScelto));
+  }
+
+  Widget _sezione(String titolo, String testo) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            titolo,
+            style: const TextStyle(
+              fontWeight: FontWeight.bold,
+              color: AppColors.primary,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(testo),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final quest = _quest;
+
+    return MobileScaffold(
+      title: 'Generatore Side Quest',
+      body: Padding(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (_pngSalvati.isNotEmpty) ...[
+              Text(
+                'Committente',
+                style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+              ),
+              const SizedBox(height: 4),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  ChoiceChip(
+                    label: const Text('Casuale'),
+                    selected: _committenteScelto == null,
+                    onSelected:
+                        (_) => setState(() => _committenteScelto = null),
+                  ),
+                  for (final png in _pngSalvati)
+                    ChoiceChip(
+                      label: Text(png.nome),
+                      selected: _committenteScelto?.id == png.id,
+                      onSelected:
+                          (_) => setState(() => _committenteScelto = png),
+                    ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.lg),
+            ],
+            ElevatedButton.icon(
+              onPressed: _genera,
+              icon: const Icon(Icons.casino),
+              label: const Text('Genera side quest'),
+            ),
+            const SizedBox(height: AppSpacing.lg),
+            if (quest == null)
+              const Text('Premi il pulsante per generare una side quest.')
+            else
+              Expanded(
+                child: SingleChildScrollView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _sezione('Obiettivo', quest.obiettivo),
+                      _sezione(
+                        'Committente',
+                        '${quest.committente.nome} '
+                            '(${quest.committente.occupazione})',
+                      ),
+                      _sezione('Complicazione', quest.complicazione),
+                      _sezione('Ricompensa', quest.ricompensa),
+                    ],
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/saved_npc_service.dart
+++ b/lib/services/saved_npc_service.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../utils/npc_generator.dart';
+import '../core/logger.dart';
+
+/// Servizio per la gestione dei PNG salvati dal Master, cosi' che un PNG
+/// generato in una sessione possa ricomparire in sessioni future della
+/// stessa campagna (es. come committente ricorrente di una side quest).
+class SavedNpcService {
+  static const String _prefsKey = 'saved_npcs';
+
+  /// Carica tutti i PNG salvati.
+  static Future<List<Png>> caricaTutti() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(_prefsKey);
+      if (raw == null || raw.isEmpty) return [];
+
+      final List<dynamic> decoded = jsonDecode(raw) as List<dynamic>;
+      final List<Png> png = [];
+
+      for (final item in decoded) {
+        try {
+          png.add(Png.fromJson(item as Map<String, dynamic>));
+        } catch (e) {
+          AppLogger.warning('PNG salvato corrotto, saltato: $e');
+        }
+      }
+
+      return png;
+    } catch (e, st) {
+      AppLogger.error('Errore nel caricamento PNG salvati', e, st);
+      return [];
+    }
+  }
+
+  /// Salva (aggiunge o aggiorna) un PNG.
+  static Future<void> salva(Png png) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final tutti = await caricaTutti();
+
+      final index = tutti.indexWhere((p) => p.id == png.id);
+      if (index >= 0) {
+        tutti[index] = png;
+      } else {
+        tutti.add(png);
+      }
+
+      final encoded = jsonEncode(tutti.map((p) => p.toJson()).toList());
+      await prefs.setString(_prefsKey, encoded);
+      AppLogger.info('PNG salvato: ${png.nome} (${png.id})');
+    } catch (e, st) {
+      AppLogger.error('Errore nel salvataggio PNG', e, st);
+      rethrow;
+    }
+  }
+
+  /// Elimina un PNG salvato per ID.
+  static Future<void> elimina(String id) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final tutti = await caricaTutti();
+      tutti.removeWhere((p) => p.id == id);
+
+      final encoded = jsonEncode(tutti.map((p) => p.toJson()).toList());
+      await prefs.setString(_prefsKey, encoded);
+      AppLogger.info('PNG eliminato: $id');
+    } catch (e, st) {
+      AppLogger.error("Errore nell'eliminazione PNG", e, st);
+      rethrow;
+    }
+  }
+}

--- a/lib/utils/npc_generator.dart
+++ b/lib/utils/npc_generator.dart
@@ -1,9 +1,17 @@
 import 'dart:math';
 
+import 'package:uuid/uuid.dart';
+
 import '../data/db_npc.dart';
 import '../data/db_nomi.dart';
 
+/// Un PNG generato. Nasce "usa e getta" (nessun salvataggio automatico),
+/// ma porta comunque un [id] stabile fin dalla creazione cosi' puo' essere
+/// salvato in un secondo momento (vedi [SavedNpcService]) e ricomparire in
+/// sessioni future della stessa campagna, es. come committente di una side
+/// quest (vedi generaSideQuest in side_quest_generator.dart).
 class Png {
+  final String id;
   final String nome;
   final String aspetto;
   final String personalita;
@@ -11,12 +19,31 @@ class Png {
   final String ganceTrama;
 
   const Png({
+    required this.id,
     required this.nome,
     required this.aspetto,
     required this.personalita,
     required this.occupazione,
     required this.ganceTrama,
   });
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'nome': nome,
+    'aspetto': aspetto,
+    'personalita': personalita,
+    'occupazione': occupazione,
+    'ganceTrama': ganceTrama,
+  };
+
+  factory Png.fromJson(Map<String, dynamic> json) => Png(
+    id: json['id'] as String,
+    nome: json['nome'] as String,
+    aspetto: json['aspetto'] as String,
+    personalita: json['personalita'] as String,
+    occupazione: json['occupazione'] as String,
+    ganceTrama: json['ganceTrama'] as String,
+  );
 }
 
 /// Genera un PNG "usa e getta" combinando un nome (da una specie D&D, vedi
@@ -26,6 +53,7 @@ class Png {
 Png generaPng({required String fonteNomi, Random? random}) {
   final rnd = random ?? Random();
   return Png(
+    id: const Uuid().v4(),
     nome: _generaNome(fonteNomi, rnd),
     aspetto: aspettiFisiciNpc[rnd.nextInt(aspettiFisiciNpc.length)],
     personalita: trattiPersonalitaNpc[rnd.nextInt(trattiPersonalitaNpc.length)],

--- a/lib/utils/side_quest_generator.dart
+++ b/lib/utils/side_quest_generator.dart
@@ -1,0 +1,43 @@
+import 'dart:math';
+
+import '../data/db_nomi.dart';
+import '../data/db_side_quest.dart';
+import 'npc_generator.dart';
+
+/// Una side quest generata: obiettivo, chi la affida, una complicazione e
+/// una ricompensa, pronta per l'improvvisazione.
+class SideQuest {
+  final String obiettivo;
+  final Png committente;
+  final String complicazione;
+  final String ricompensa;
+
+  const SideQuest({
+    required this.obiettivo,
+    required this.committente,
+    required this.complicazione,
+    required this.ricompensa,
+  });
+}
+
+/// Genera una side quest casuale. Se [committente] non e' passato, ne viene
+/// generato uno nuovo "usa e getta" (vedi [generaPng]); passandone uno gia'
+/// salvato (vedi SavedNpcService) la stessa persona puo' ricomparire come
+/// committente in altre sessioni della campagna.
+SideQuest generaSideQuest({Png? committente, Random? random}) {
+  final rnd = random ?? Random();
+  return SideQuest(
+    obiettivo: obiettiviSideQuest[rnd.nextInt(obiettiviSideQuest.length)],
+    committente:
+        committente ??
+        generaPng(
+          fonteNomi: nomiPerSpecie.keys.elementAt(
+            rnd.nextInt(nomiPerSpecie.length),
+          ),
+          random: rnd,
+        ),
+    complicazione:
+        complicazioniSideQuest[rnd.nextInt(complicazioniSideQuest.length)],
+    ricompensa: ricompenseSideQuest[rnd.nextInt(ricompenseSideQuest.length)],
+  );
+}

--- a/test/saved_npc_service_test.dart
+++ b/test/saved_npc_service_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:master_aid/services/saved_npc_service.dart';
+import 'package:master_aid/utils/npc_generator.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  Png creaPng({String id = 'png-1'}) => Png(
+    id: id,
+    nome: 'Elandra',
+    aspetto: 'Occhi eterocromatici',
+    personalita: 'Diretta fino alla scortesia',
+    occupazione: 'Locandiera',
+    ganceTrama: 'Cerca un oggetto rubato',
+  );
+
+  test(
+    'caricaTutti restituisce lista vuota se non c\'e\' nulla salvato',
+    () async {
+      expect(await SavedNpcService.caricaTutti(), isEmpty);
+    },
+  );
+
+  test('salva/caricaTutti fanno un round-trip fedele', () async {
+    final png = creaPng();
+    await SavedNpcService.salva(png);
+
+    final tutti = await SavedNpcService.caricaTutti();
+    expect(tutti, hasLength(1));
+    expect(tutti.first.id, png.id);
+    expect(tutti.first.nome, png.nome);
+    expect(tutti.first.occupazione, png.occupazione);
+  });
+
+  test('salva con lo stesso id aggiorna invece di duplicare', () async {
+    await SavedNpcService.salva(creaPng());
+    await SavedNpcService.salva(creaPng());
+
+    final tutti = await SavedNpcService.caricaTutti();
+    expect(tutti, hasLength(1));
+  });
+
+  test('elimina rimuove il PNG salvato', () async {
+    final png = creaPng();
+    await SavedNpcService.salva(png);
+    await SavedNpcService.elimina(png.id);
+
+    expect(await SavedNpcService.caricaTutti(), isEmpty);
+  });
+}

--- a/test/side_quest_generator_test.dart
+++ b/test/side_quest_generator_test.dart
@@ -1,0 +1,41 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:master_aid/utils/npc_generator.dart';
+import 'package:master_aid/utils/side_quest_generator.dart';
+
+void main() {
+  group('generaSideQuest', () {
+    test('genera tutti i campi non vuoti con committente casuale', () {
+      final quest = generaSideQuest(random: Random(42));
+      expect(quest.obiettivo, isNotEmpty);
+      expect(quest.complicazione, isNotEmpty);
+      expect(quest.ricompensa, isNotEmpty);
+      expect(quest.committente.nome, isNotEmpty);
+    });
+
+    test('usa il committente passato invece di generarne uno nuovo', () {
+      final png = generaPng(fonteNomi: 'Elfo', random: Random(1));
+      final quest = generaSideQuest(committente: png, random: Random(42));
+      expect(quest.committente.id, png.id);
+      expect(quest.committente.nome, png.nome);
+    });
+
+    test('con lo stesso seed produce lo stesso risultato', () {
+      final quest1 = generaSideQuest(random: Random(7));
+      final quest2 = generaSideQuest(random: Random(7));
+      expect(quest1.obiettivo, quest2.obiettivo);
+      expect(quest1.complicazione, quest2.complicazione);
+      expect(quest1.ricompensa, quest2.ricompensa);
+      expect(quest1.committente.nome, quest2.committente.nome);
+    });
+
+    test('seed diversi producono variazione', () {
+      final risultati = <String>{};
+      for (var i = 0; i < 10; i++) {
+        risultati.add(generaSideQuest(random: Random(i)).obiettivo);
+      }
+      expect(risultati.length, greaterThan(1));
+    });
+  });
+}


### PR DESCRIPTION
Closes #92

## Cosa fa

Aggiunge un generatore di side quest casuali e la possibilità di salvare i PNG generati per riusarli in sessioni future della stessa campagna.

### Generatore Side Quest
- `lib/data/db_side_quest.dart`: tabelle curate in italiano (obiettivo, complicazione, ricompensa).
- `lib/utils/side_quest_generator.dart`: `generaSideQuest(...)`, funzione pura. Se non si passa un committente, ne genera uno nuovo usa e getta (come il Generatore PNG); si può anche passare un PNG già salvato.
- `lib/screens/side_quest_generator_screen.dart`: schermata di generazione, con selettore del committente tra i PNG salvati o casuale.
- Nuova card "Generatore Side Quest" in home.

### PNG salvabili (prerequisito per il committente ricorrente)
- `Png` (in `npc_generator.dart`) ha ora un `id` stabile e `toJson`/`fromJson`.
- `lib/services/saved_npc_service.dart`: CRUD via SharedPreferences, stesso pattern di `HomebrewMonsterService`.
- Nuova schermata "PNG salvati" raggiungibile dal Generatore PNG, con un pulsante "Salva" dopo la generazione.

## Verifica

- `flutter analyze` → nessun problema
- `flutter test` → tutti passano (72 test totali, inclusi i nuovi per il generatore side quest e per `SavedNpcService`)
- `dart format --set-exit-if-changed .` → pulito
